### PR TITLE
feat: add render list items functionality

### DIFF
--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -7,11 +7,9 @@ export function List({ data }) {
 				Hello from the <code>/list</code> page!
 			</p>
 			<ul>
-				{/**
-				 * TODO: write some JavaScript that renders the `data` array
-				 * using the `ListItem` component that's imported at the top
-				 * of this file.
-				 */}
+				{data.map(({ name, id }) => (
+					<ListItem name={name} key={id} />
+				))}
 			</ul>
 		</>
 	);


### PR DESCRIPTION
## Description

This PR renders shopping list item names from the Firestore database onto the "/list" page. This is done by mapping the data into a `listItem` component.

## Related Issue

Closes #1 

## Acceptance Criteria

- [x] The following have been added as project dependencies: firebase & react-firestore
- [x] Make a change in the Firestore database and it shows up in the app
- [x] Make a change in the app and it shows up in the Firestore database

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

![Screen Shot 2022-07-06 at 1 51 08 PM](https://user-images.githubusercontent.com/90414254/177621939-f46bc397-4872-493c-87fb-cfbd99bb25a1.png)

### After

![Screen Shot 2022-07-06 at 1 51 50 PM](https://user-images.githubusercontent.com/90414254/177622042-dd1045e1-ea32-4530-a2f6-69330b22f1dd.png)

## Testing Steps / QA Criteria

- From your terminal, pull down this branch with `git pull origin yh-ad-listItems-1` and check that branch out with `git checkout  yh-ad-listItems-1` .
- Start program with `npm start`.
- Go to localhost:3000/list and see all list items render on the page.
