### PR TITLE
`List` Welcome Dialog

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -57,7 +57,10 @@ export function App() {
 		<Routes>
 			<Route path="/" element={<Layout />}>
 				<Route index element={<Home setListToken={setListToken} />} />
-				<Route path="/list" element={<List data={data} />} />
+				<Route
+					path="/list"
+					element={<List data={data} listToken={listToken} />}
+				/>
 				<Route path="/add-item" element={<AddItem listToken={listToken} />} />
 			</Route>
 		</Routes>

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -4,6 +4,9 @@ import {
 	getFirestore,
 	onSnapshot,
 	addDoc,
+	doc,
+	getDoc, //this is read only?
+	getDocs, //this returns query snapshot?
 } from 'firebase/firestore';
 
 import { getFutureDate } from '../utils';
@@ -30,6 +33,14 @@ const db = getFirestore(app);
  */
 export function streamListItems(listId, handleSuccess) {
 	const listCollectionRef = collection(db, listId);
+	// see https://firebase.google.com/docs/firestore/query-data/get-data
+
+	const querySnapshot = getDocs(listCollectionRef);
+	// but this just gets docs assuming listCollection exists. falsy default if empty.
+
+	// const docRef = doc(db, "tokens", listId)
+	// const docSnap = getDoc(docRef)
+	// console.log(`${docSnap.exists() ? `${listId} was found in collection` : `${listId} not found`}`)
 	return onSnapshot(listCollectionRef, handleSuccess);
 }
 
@@ -78,7 +89,7 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 }
 
 export async function updateItem() {
-	/**
+	/*
 	 * TODO: Fill this out so that it uses the correct Firestore function
 	 * to update an existing item! You'll need to figure out what arguments
 	 * this function must accept!

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -33,14 +33,6 @@ const db = getFirestore(app);
  */
 export function streamListItems(listId, handleSuccess) {
 	const listCollectionRef = collection(db, listId);
-	// see https://firebase.google.com/docs/firestore/query-data/get-data
-
-	const querySnapshot = getDocs(listCollectionRef);
-	// but this just gets docs assuming listCollection exists. falsy default if empty.
-
-	// const docRef = doc(db, "tokens", listId)
-	// const docSnap = getDoc(docRef)
-	// console.log(`${docSnap.exists() ? `${listId} was found in collection` : `${listId} not found`}`)
 	return onSnapshot(listCollectionRef, handleSuccess);
 }
 

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
-
+import { useNavigate } from 'react-router-dom';
 import { ListItem } from '../components';
 
 export function List({ data }) {
+	const navigate = useNavigate();
 	const [searchTerm, setSearchTerm] = useState('');
 
 	const filterList = (list) => {
@@ -18,29 +19,56 @@ export function List({ data }) {
 		setSearchTerm('');
 	};
 
+	/*
+	if list is empty (length === 0)
+		hide filter option
+		show welcome prompt
+			Welcome to your smart shopping list!
+			You must add at least one item to start sharing your list with others.
+
+		show button to "add item"
+			button redirects to Add Item page
+	*/
+
 	return (
 		<>
 			<p>
 				Hello from the <code>/list</code> page!
 			</p>
-			<form onSubmit={(e) => e.preventDefault()}>
-				<label>
-					Filter Items
-					<input
-						type="text"
-						placeholder="start typing here..."
-						id="filter"
-						name="filter"
-						value={searchTerm}
-						onChange={(e) => {
-							setSearchTerm(e.target.value);
-						}}
-					/>
-				</label>
-			</form>
-			<button type="button" onClick={clearSearchTerm}>
-				clear
-			</button>
+
+			{data.length ? (
+				<div>
+					<form onSubmit={(e) => e.preventDefault()}>
+						<label>
+							Filter Items
+							<input
+								type="text"
+								placeholder="start typing here..."
+								id="filter"
+								name="filter"
+								value={searchTerm}
+								onChange={(e) => {
+									setSearchTerm(e.target.value);
+								}}
+							/>
+						</label>
+					</form>
+					<button type="button" onClick={clearSearchTerm}>
+						clear
+					</button>
+				</div>
+			) : (
+				<div>
+					<h2>Welcome to your smart shopping list!</h2>
+					<p>
+						You must add at least one item to start sharing your list with
+						others.
+					</p>
+					<button type="button" onClick={() => navigate('/add-item')}>
+						Start adding items
+					</button>
+				</div>
+			)}
 
 			<ul>
 				{filterList(data).map(({ name, id }) => (

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -5,10 +5,10 @@ import { ListItem } from '../components';
 export function List({ data, listToken }) {
 	const navigate = useNavigate();
 	const [searchTerm, setSearchTerm] = useState('');
-	const [copied, setCopied] = useState(false);
+	const [copied, setCopied] = useState('');
 
 	useEffect(() => {
-		if (copied) setTimeout(() => setCopied(false), 2000);
+		if (copied) setTimeout(() => setCopied(''), 2000);
 	}, [copied]);
 
 	const filterList = (list) => {
@@ -25,8 +25,10 @@ export function List({ data, listToken }) {
 	};
 
 	const copyToken = () => {
-		navigator.clipboard.writeText(listToken);
-		setCopied(true);
+		navigator.clipboard
+			.writeText(listToken)
+			.then(() => setCopied('Copied!'))
+			.catch(() => setCopied('Not Copied.'));
 	};
 
 	return (
@@ -53,7 +55,7 @@ export function List({ data, listToken }) {
 						<p>
 							Copy token to allow others join your list:
 							<button onClick={copyToken} id="token">
-								{copied ? 'Copied!' : listToken}
+								{copied ? copied : listToken}
 							</button>
 						</p>
 					</div>

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -1,10 +1,15 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ListItem } from '../components';
 
-export function List({ data }) {
+export function List({ data, listToken }) {
 	const navigate = useNavigate();
 	const [searchTerm, setSearchTerm] = useState('');
+	const [copied, setCopied] = useState(false);
+
+	useEffect(() => {
+		if (copied) setTimeout(() => setCopied(false), 2000);
+	}, [copied]);
 
 	const filterList = (list) => {
 		const cleanup = (inputString) => {
@@ -19,28 +24,39 @@ export function List({ data }) {
 		setSearchTerm('');
 	};
 
+	const copyToken = () => {
+		navigator.clipboard.writeText(listToken);
+		setCopied(true);
+	};
+
 	return (
 		<>
 			{data.length ? (
 				<div>
-					<form onSubmit={(e) => e.preventDefault()}>
-						<label>
-							Filter Items
-							<input
-								type="text"
-								placeholder="start typing here..."
-								id="filter"
-								name="filter"
-								value={searchTerm}
-								onChange={(e) => {
-									setSearchTerm(e.target.value);
-								}}
-							/>
-						</label>
-					</form>
-					<button type="button" onClick={clearSearchTerm}>
+					<label>
+						Filter Items
+						<input
+							type="text"
+							placeholder="start typing here..."
+							id="filter"
+							name="filter"
+							value={searchTerm}
+							onChange={(e) => {
+								setSearchTerm(e.target.value);
+							}}
+						/>
+					</label>
+					<button type="button" onClick={clearSearchTerm} aria-live="polite">
 						clear
 					</button>
+					<div>
+						<p>
+							Copy token to allow others join your list:
+							<button onClick={copyToken} id="token">
+								{copied ? 'Copied!' : listToken}
+							</button>
+						</p>
+					</div>
 				</div>
 			) : (
 				<div>

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -21,10 +21,6 @@ export function List({ data }) {
 
 	return (
 		<>
-			<p>
-				Hello from the <code>/list</code> page!
-			</p>
-
 			{data.length ? (
 				<div>
 					<form onSubmit={(e) => e.preventDefault()}>
@@ -50,8 +46,9 @@ export function List({ data }) {
 				<div>
 					<h2>Welcome to your smart shopping list!</h2>
 					<p>
-						You must add at least one item to start sharing your list with
-						others.
+						This app will learn from your purchasing habits and help you
+						prioritize and plan your shopping list. You must add at least one
+						item to start sharing your list with others.
 					</p>
 					<button type="button" onClick={() => navigate('/add-item')}>
 						Start adding items

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -19,17 +19,6 @@ export function List({ data }) {
 		setSearchTerm('');
 	};
 
-	/*
-	if list is empty (length === 0)
-		hide filter option
-		show welcome prompt
-			Welcome to your smart shopping list!
-			You must add at least one item to start sharing your list with others.
-
-		show button to "add item"
-			button redirects to Add Item page
-	*/
-
 	return (
 		<>
 			<p>


### PR DESCRIPTION
## Description

Adds a welcoming dialog to the `List` page that shows if user has not added an item to their list yet. Redirects the user to the `Add Items` page with a button dialog.

Welcoming dialogue is rendered conditionally based on existence/length of list (i.e., newly generated listToken from Home.js). Note that anyone given the same token to attempt to join the list on another device or browser will be unable to join (from previous issues). 

If list has at least one item, the list filtering UI will be rendered instead.  We also added a button and instructions for sharing the list (by the list token) once an item has been added. 

### Considerations
- For later issue: Generate 1 placeholder item upon generating a new token to give users the option to share "empty" lists. (Will need to remove or excise placeholder item following first real user-generated item.)
- As noted, this dialog also includes a button that redirects user to Add Items. We decided to not recreate the functionality of the add item list/complicate too much.
- Although the acceptance criteria did not specify showing the shareable list token, this seemed relevant to the goals of this specific issue and does not seem to be addressed in later user stories.

## Related Issue

Closes #7.

## Acceptance Criteria

- [x]  The list view, when there are no items to display, should show a prompt (e.g., a button) for the user to add their first item
## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before
![issue-7-before](https://user-images.githubusercontent.com/102257735/181505817-a7b877e0-8793-4bbf-95f3-87eac3c2d44c.png)

### After
Conditionally shown welcome dialog 
![issue-7-after](https://user-images.githubusercontent.com/102257735/181505210-8d29a916-7b68-4d58-b310-87bb1202ffd5.png)
Additional button to copy and share list token after at least one item is added
![issue-7-after-item](https://user-images.githubusercontent.com/102257735/181655538-7d072a01-a71c-4903-b08e-40007f275066.png)

## Testing Steps / QA Criteria
1. Check out branch `xc-hy-listwelcome-7` and run with `npm start`
2. Try joining "my test list" (has >=1 items). List page should show filtering option and item names.
3. From Home page, try generating a new list token. Upon redirect to List page,  filter and list items should be visible. 
4. From Home page, generate new list token. Upon redirect to List, welcome dialog and button should be visible. Clicking the button should redirect to Add Item page.
5. From Home page and on a different browser or device (get token string from local storage of the browser), try joining the new empty list. It should not be possible.
6. From original browser where token was generated, add one item. Try again to join the list from other browser. It should work and show filter option, token copying button, plus the new item in the List page.