### PR TITLE
Estimate purchase date upon item purchase (user checks off)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -61,7 +61,10 @@ export function App() {
 					path="/list"
 					element={<List data={data} listToken={listToken} />}
 				/>
-				<Route path="/add-item" element={<AddItem listToken={listToken} />} />
+				<Route
+					path="/add-item"
+					element={<AddItem data={data} listToken={listToken} />}
+				/>
 			</Route>
 		</Routes>
 	);

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -124,14 +124,21 @@ export async function updateItem(
 
 	const listCollectionRef = collection(db, listId);
 	const listItemRef = doc(listCollectionRef, itemId);
-	if (isChecked) {
+
+	if (isChecked /*&& currentTime > dateLastPurchased.toMillis() + 50000*/) {
 		await updateDoc(listItemRef, {
 			dateLastPurchased: currentDate,
 			isChecked: isChecked,
 			totalPurchases: increment(1),
-			dateNextPurchased: actualDateNextPurchased, //updated with
+			dateNextPurchased: actualDateNextPurchased,
 		});
+		/*} else if (isChecked && currentTime < dateLastPurchased.toMillis() + 50000){
+		console.log('not updating bc too soon')
+		await updateDoc(listItemRef, {
+			isChecked: isChecked,
+		});*/
 	} else {
+		// not checked at all
 		await updateDoc(listItemRef, {
 			isChecked: isChecked,
 		});

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -9,7 +9,7 @@ import {
 	increment,
 } from 'firebase/firestore';
 
-import { getFutureDate, getDaysBetweenDates } from '../utils';
+import { getFutureDate } from '../utils';
 
 const firebaseConfig = {
 	apiKey: 'AIzaSyCfI_TVGKMzq7CaxBRQZAbqejH713TzGeg',

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -80,12 +80,12 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 	});
 }
 
-export async function updateItem(listId, { itemId, isChecked, currentTime }) {
+export async function updateItem(listId, { itemId, isChecked, currentDate }) {
 	const listCollectionRef = collection(db, listId);
 	const listItemRef = doc(listCollectionRef, itemId);
 	if (isChecked) {
 		await updateDoc(listItemRef, {
-			dateLastPurchased: currentTime,
+			dateLastPurchased: currentDate,
 			isChecked: isChecked,
 			totalPurchases: increment(1),
 		});

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -114,7 +114,7 @@ export async function updateItem(
 		// prevEst remains undefined in this scenario
 	}
 	let daysToNextPurchase = calculateEstimate(
-		prevEst, // effectively, prevEst || 14 here?
+		prevEst, // effectively, prevEst || 14 here
 		daysSinceLastPurchase,
 		totalPurchases,
 	); //returns integer - days to next purchase.
@@ -125,8 +125,8 @@ export async function updateItem(
 	const listCollectionRef = collection(db, listId);
 	const listItemRef = doc(listCollectionRef, itemId);
 	if (
-		(isChecked && !dateLastPurchased) ||
-		(isChecked && currentTime > dateLastPurchased.toMillis() + 50000)
+		(isChecked && !dateLastPurchased) || //first-time purchase should go through
+		(isChecked && currentTime > dateLastPurchased.toMillis() + 50000) //allow if 50s elapsed since last time checked
 	) {
 		await updateDoc(listItemRef, {
 			dateLastPurchased: currentDate,

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -135,7 +135,6 @@ export async function updateItem(
 			dateNextPurchased: actualDateNextPurchased,
 		});
 	} else {
-		console.log('rejected');
 		await updateDoc(listItemRef, {
 			isChecked: isChecked,
 		});

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -94,18 +94,10 @@ export async function updateItem(
 		totalPurchases,
 	},
 ) {
-	// let currentDate = getFutureDate(0);
-	// let currentTimeInMS = currentTime.getTime();
 	let daysSinceLastPurchase;
 	let prevEst;
 
-	if (!dateLastPurchased) {
-		daysSinceLastPurchase = Math.max(
-			1,
-			getDaysBetweenDates(dateCreated.toMillis(), currentTime),
-		);
-		// prevEst remains undefined in this scenario
-	} else {
+	if (dateLastPurchased) {
 		daysSinceLastPurchase = getDaysBetweenDates(
 			dateLastPurchased.toMillis(),
 			currentTime,
@@ -114,7 +106,32 @@ export async function updateItem(
 			dateLastPurchased.toMillis(),
 			dateNextPurchased.toMillis(),
 		);
+	} else {
+		daysSinceLastPurchase =
+			// Math.max(
+			// 	1,
+			getDaysBetweenDates(dateCreated.toMillis(), currentTime);
+		// );
+		// prevEst remains undefined in this scenario
 	}
+
+	// RESHUFFLED ABOVE
+	// if (!dateLastPurchased) {
+	// 	daysSinceLastPurchase = Math.max(
+	// 		1,
+	// 		getDaysBetweenDates(dateCreated.toMillis(), currentTime),
+	// 	);
+	// 	// prevEst remains undefined in this scenario
+	// } else {
+	// 	daysSinceLastPurchase = getDaysBetweenDates(
+	// 		dateLastPurchased.toMillis(),
+	// 		currentTime,
+	// 	);
+	// 	prevEst = getDaysBetweenDates(
+	// 		dateLastPurchased.toMillis(),
+	// 		dateNextPurchased.toMillis(),
+	// 	);
+	// }
 	let daysToNextPurchase = calculateEstimate(
 		prevEst, // effectively, prevEst || 14 here?
 		daysSinceLastPurchase,
@@ -122,8 +139,6 @@ export async function updateItem(
 	); //returns integer - days to next purchase. Then turn into date:
 
 	let actualDateNextPurchased = getFutureDate(daysToNextPurchase);
-	// this is what should come from firebase. solely for console log/testing
-	let initialDateNext = dateNextPurchased.toDate();
 
 	const listCollectionRef = collection(db, listId);
 	const listItemRef = doc(listCollectionRef, itemId);
@@ -134,9 +149,6 @@ export async function updateItem(
 			totalPurchases: increment(1),
 			dateNextPurchased: actualDateNextPurchased, //updated with
 		});
-		console.log(
-			`actual date next purchase ${actualDateNextPurchased}; total purchse number ${totalPurchases}; initial date next from firebase ${initialDateNext}`,
-		);
 	} else {
 		await updateDoc(listItemRef, {
 			isChecked: isChecked,

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -124,21 +124,18 @@ export async function updateItem(
 
 	const listCollectionRef = collection(db, listId);
 	const listItemRef = doc(listCollectionRef, itemId);
-
-	if (isChecked /*&& currentTime > dateLastPurchased.toMillis() + 50000*/) {
+	if (
+		(isChecked && !dateLastPurchased) ||
+		(isChecked && currentTime > dateLastPurchased.toMillis() + 50000)
+	) {
 		await updateDoc(listItemRef, {
 			dateLastPurchased: currentDate,
 			isChecked: isChecked,
 			totalPurchases: increment(1),
 			dateNextPurchased: actualDateNextPurchased,
 		});
-		/*} else if (isChecked && currentTime < dateLastPurchased.toMillis() + 50000){
-		console.log('not updating bc too soon')
-		await updateDoc(listItemRef, {
-			isChecked: isChecked,
-		});*/
 	} else {
-		// not checked at all
+		console.log('rejected');
 		await updateDoc(listItemRef, {
 			isChecked: isChecked,
 		});

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -107,37 +107,19 @@ export async function updateItem(
 			dateNextPurchased.toMillis(),
 		);
 	} else {
-		daysSinceLastPurchase =
-			// Math.max(
-			// 	1,
-			getDaysBetweenDates(dateCreated.toMillis(), currentTime);
-		// );
+		daysSinceLastPurchase = Math.max(
+			1,
+			getDaysBetweenDates(dateCreated.toMillis(), currentTime),
+		);
 		// prevEst remains undefined in this scenario
 	}
-
-	// RESHUFFLED ABOVE
-	// if (!dateLastPurchased) {
-	// 	daysSinceLastPurchase = Math.max(
-	// 		1,
-	// 		getDaysBetweenDates(dateCreated.toMillis(), currentTime),
-	// 	);
-	// 	// prevEst remains undefined in this scenario
-	// } else {
-	// 	daysSinceLastPurchase = getDaysBetweenDates(
-	// 		dateLastPurchased.toMillis(),
-	// 		currentTime,
-	// 	);
-	// 	prevEst = getDaysBetweenDates(
-	// 		dateLastPurchased.toMillis(),
-	// 		dateNextPurchased.toMillis(),
-	// 	);
-	// }
 	let daysToNextPurchase = calculateEstimate(
 		prevEst, // effectively, prevEst || 14 here?
 		daysSinceLastPurchase,
 		totalPurchases,
-	); //returns integer - days to next purchase. Then turn into date:
+	); //returns integer - days to next purchase.
 
+	// Then turn into date:
 	let actualDateNextPurchased = getFutureDate(daysToNextPurchase);
 
 	const listCollectionRef = collection(db, listId);

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -80,7 +80,10 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 	});
 }
 
-export async function updateItem(listId, { itemId, isChecked, currentDate }) {
+export async function updateItem(
+	listId,
+	{ itemId, isChecked, currentDate, dateNextPurchased },
+) {
 	const listCollectionRef = collection(db, listId);
 	const listItemRef = doc(listCollectionRef, itemId);
 	if (isChecked) {
@@ -88,6 +91,7 @@ export async function updateItem(listId, { itemId, isChecked, currentDate }) {
 			dateLastPurchased: currentDate,
 			isChecked: isChecked,
 			totalPurchases: increment(1),
+			dateNextPurchased: dateNextPurchased,
 		});
 	} else {
 		await updateDoc(listItemRef, {

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -9,7 +9,7 @@ import {
 	increment,
 } from 'firebase/firestore';
 
-import { getFutureDate } from '../utils';
+import { getFutureDate, getDaysBetweenDates } from '../utils';
 
 const firebaseConfig = {
 	apiKey: 'AIzaSyCfI_TVGKMzq7CaxBRQZAbqejH713TzGeg',

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -26,6 +26,8 @@ export function ListItem({
 				itemId: itemId,
 				isChecked: isPurchased,
 				dateCreated: dateCreated,
+				dateLastPurchased: dateLastPurchased, // added
+
 				currentDate: getFutureDate(0),
 				currentTime: new Date().getTime(),
 				dateNextPurchased: dateNextPurchased, //reassigned inside the function - this passes initial dNP

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 
 import { updateItem } from '../api/firebase';
 
-import { getFutureDate } from '../utils';
+import { getFutureDate, getDaysBetweenDates } from '../utils';
 
 import './ListItem.css';
 
@@ -27,6 +27,7 @@ export function ListItem({
 
 				//getDaysBetweenDates(currentTime) //date is in ms, returns daysSinceLastPurchase
 				// calculateEstimate(prevEst, daysSinceLastPurchase, totalPurchases) //returns integer - days to next purchase.
+				//
 				// does not go into Firebase
 			});
 		}

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -64,7 +64,9 @@ export function ListItem({
 				totalPurchases,
 			); //returns integer - days to next purchase. Then turn into date
 			let actualDateNextPurchased = getFutureDate(daysToNextPurchase);
-			console.log(`actual date next purchase ${actualDateNextPurchased}`);
+			console.log(
+				`actual date next purchase ${actualDateNextPurchased}; total purchse number ${totalPurchases}`,
+			);
 
 			updateItem(listToken, {
 				itemId: itemId,

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -13,6 +13,7 @@ export function ListItem({
 	itemId,
 	name,
 	isChecked,
+	dateCreated,
 	dateLastPurchased,
 	dateNextPurchased,
 	totalPurchases,
@@ -34,6 +35,11 @@ export function ListItem({
 			let prevEst;
 			if (!dateLastPurchased) {
 				daysSinceLastPurchase = 0;
+				// use date created instead for prevEst param?
+				prevEst = getDaysBetweenDates(
+					dateCreated.toMillis(),
+					dateNextPurchased.toMillis(),
+				);
 			} else {
 				daysSinceLastPurchase = getDaysBetweenDates(
 					dateLastPurchased.toMillis(),

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -4,6 +4,8 @@ import { updateItem } from '../api/firebase';
 
 import { getFutureDate, getDaysBetweenDates } from '../utils';
 
+import { calculateEstimate } from '@the-collab-lab/shopping-list-utils/dist/calculateEstimate';
+
 import './ListItem.css';
 
 export function ListItem({
@@ -12,6 +14,8 @@ export function ListItem({
 	name,
 	isChecked,
 	dateLastPurchased,
+	dateNextPurchased,
+	totalPurchases,
 }) {
 	const DAYINMS = 86400000;
 	// sync up checked or not checked data from the database to the page upon page refresh
@@ -20,15 +24,30 @@ export function ListItem({
 	useEffect(() => {
 		// only update item when the checkbox has been checked. Don't update when the page just loaded and "isPurchased" is changed accordingly
 		if (isChecked !== isPurchased) {
+			let currentTime = getFutureDate(0);
+			let currentTimeInMS = new Date().getTime();
+
+			let daysSinceLastPurchase = getDaysBetweenDates(
+				dateLastPurchased,
+				currentTimeInMS,
+			); //date is in ms, returns daysSinceLastPurchase
+			let prevEst = getDaysBetweenDates(dateLastPurchased, dateNextPurchased); //any way to grab the days elapsed sooner?(7/14/21)
+			console.log(dateNextPurchased);
+			let daysToNextPurchase = calculateEstimate(
+				prevEst,
+				daysSinceLastPurchase,
+				totalPurchases,
+			); //returns integer - days to next purchase.
+			// ^ turn into date
+			let actualDateNextPurchase = getFutureDate(daysToNextPurchase);
+			console.log(`actual date next purchase ${actualDateNextPurchase}`);
+			// dateNextPurchased: //will we reassign at some point?
+			// does not go into Firebase
+
 			updateItem(listToken, {
 				itemId: itemId,
 				isChecked: isPurchased,
-				currentTime: getFutureDate(0),
-
-				//getDaysBetweenDates(currentTime) //date is in ms, returns daysSinceLastPurchase
-				// calculateEstimate(prevEst, daysSinceLastPurchase, totalPurchases) //returns integer - days to next purchase.
-				//
-				// does not go into Firebase
+				currentTime: currentTime,
 			});
 		}
 	}, [isPurchased, isChecked, itemId, listToken]);

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -24,6 +24,10 @@ export function ListItem({
 				itemId: itemId,
 				isChecked: isPurchased,
 				currentTime: getFutureDate(0),
+
+				//getDaysBetweenDates(currentTime) //date is in ms, returns daysSinceLastPurchase
+				// calculateEstimate(prevEst, daysSinceLastPurchase, totalPurchases) //returns integer - days to next purchase.
+				// does not go into Firebase
 			});
 		}
 	}, [isPurchased, isChecked, itemId, listToken]);

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -24,7 +24,7 @@ export function ListItem({
 	useEffect(() => {
 		// only update item when the checkbox has been checked. Don't update when the page just loaded and "isPurchased" is changed accordingly
 		if (isChecked !== isPurchased) {
-			let currentTime = getFutureDate(0);
+			let currentDate = getFutureDate(0);
 			let currentTimeInMS = new Date().getTime();
 
 			let daysSinceLastPurchase = getDaysBetweenDates(
@@ -47,7 +47,7 @@ export function ListItem({
 			updateItem(listToken, {
 				itemId: itemId,
 				isChecked: isPurchased,
-				currentTime: currentTime,
+				currentDate: currentDate,
 			});
 		}
 	}, [isPurchased, isChecked, itemId, listToken]);

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -64,8 +64,13 @@ export function ListItem({
 				totalPurchases,
 			); //returns integer - days to next purchase. Then turn into date
 			let actualDateNextPurchased = getFutureDate(daysToNextPurchase);
+
+			// this is what should come from firebase
+			let initialDateNext = dateNextPurchased.toDate();
+
+			// current issue: freq skews hard towards latest purchase - bug or just misuse of app?
 			console.log(
-				`actual date next purchase ${actualDateNextPurchased}; total purchse number ${totalPurchases}`,
+				`actual date next purchase ${actualDateNextPurchased}; total purchse number ${totalPurchases}; initial date next from firebase ${initialDateNext}`,
 			);
 
 			updateItem(listToken, {

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -41,6 +41,7 @@ export function ListItem({
 				);
 
 				// do the calculateEstimate docs actually require default val of prevEst to be 14 if none supplied? if so, why 14 and not 7?
+				// per calcEstimate, it should be fine to pass prevEst as-is (leave undefined, commenting out lines 45-47) and it should default to 14.
 				prevEst = getDaysBetweenDates(
 					dateCreated.toMillis(),
 					dateNextPurchased.toMillis(),

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -21,9 +21,7 @@ export function ListItem({
 	const [isPurchased, setIsPurchased] = useState(isChecked);
 
 	useEffect(() => {
-		// only update item when the checkbox has been checked. Don't update when the page just loaded and "isPurchased" is changed accordingly
 		if (isChecked !== isPurchased) {
-			// currently: checked item unchecks quickly and rechecks (re-rendering?) - uncontrolled total purchases incrementation
 			updateItem(listToken, {
 				itemId: itemId,
 				isChecked: isPurchased,
@@ -34,7 +32,7 @@ export function ListItem({
 				totalPurchases: totalPurchases,
 			});
 		}
-	}, [isPurchased, itemId, listToken]); //had dateNextPurchased, isChecked
+	}, [isPurchased, itemId, listToken]); //excluding isChecked - fixes looping and doublecounting
 
 	useEffect(() => {
 		if (dateLastPurchased) {

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -31,10 +31,15 @@ export function ListItem({
 			let daysSinceLastPurchase;
 			let prevEst;
 			if (!dateLastPurchased) {
-				daysSinceLastPurchase = 0;
-				// uses date created if no record of previous buys/null?
-				// do the calculateEstimate docs actually require default val to be 14 if none supplied? if so, why 14 and not 7?
+				// daysSinceLastPurchase = 0;  //original approach different from calculateEstimate docs
 
+				// following calculateEstimate docs, uses date created if no record of previous buys/null
+				daysSinceLastPurchase = getDaysBetweenDates(
+					dateCreated.toMillis(),
+					currentTimeInMS,
+				);
+
+				// do the calculateEstimate docs actually require default val of prevEst to be 14 if none supplied? if so, why 14 and not 7?
 				prevEst = getDaysBetweenDates(
 					dateCreated.toMillis(),
 					dateNextPurchased.toMillis(),
@@ -52,7 +57,7 @@ export function ListItem({
 			console.log(`current Time ${currentTimeInMS}`);
 			console.log(`dateLastPurchased ${dateLastPurchased}`);
 			let daysToNextPurchase = calculateEstimate(
-				prevEst,
+				prevEst, // is 14 supposed to be default if none? i.e., prevEst || 14 here?
 				daysSinceLastPurchase,
 				// why do calculateEstimate docs prefer to set this as  number of days since the item was added to the list (if no previous purchase)?
 				//https://github.com/the-collab-lab/shopping-list-utils/blob/main/src/calculateEstimate/index.ts

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -32,7 +32,9 @@ export function ListItem({
 			let prevEst;
 			if (!dateLastPurchased) {
 				daysSinceLastPurchase = 0;
-				// use date created if no record of previous buys/null
+				// uses date created if no record of previous buys/null?
+				// do the calculateEstimate docs actually require default val to be 14 if none supplied? if so, why 14 and not 7?
+
 				prevEst = getDaysBetweenDates(
 					dateCreated.toMillis(),
 					dateNextPurchased.toMillis(),
@@ -47,15 +49,17 @@ export function ListItem({
 					dateNextPurchased.toMillis(),
 				); //any way to grab the days elapsed sooner?(7/14/21)
 			}
-			// console.log(`current Time ${currentTimeInMS}`)
-			// console.log(`dateLastPurchased ${dateLastPurchased}`)
+			console.log(`current Time ${currentTimeInMS}`);
+			console.log(`dateLastPurchased ${dateLastPurchased}`);
 			let daysToNextPurchase = calculateEstimate(
 				prevEst,
 				daysSinceLastPurchase,
+				// why do calculateEstimate docs prefer to set this as  number of days since the item was added to the list (if no previous purchase)?
+				//https://github.com/the-collab-lab/shopping-list-utils/blob/main/src/calculateEstimate/index.ts
 				totalPurchases,
 			); //returns integer - days to next purchase. Then turn into date
 			let actualDateNextPurchased = getFutureDate(daysToNextPurchase);
-			// console.log(`actual date next purchase ${actualDateNextPurchased}`);
+			console.log(`actual date next purchase ${actualDateNextPurchased}`);
 
 			updateItem(listToken, {
 				itemId: itemId,

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -34,9 +34,10 @@ export function ListItem({
 				// daysSinceLastPurchase = 0;  //original approach different from calculateEstimate docs
 
 				// following calculateEstimate docs, uses date created if no record of previous buys/null
-				daysSinceLastPurchase = getDaysBetweenDates(
-					dateCreated.toMillis(),
-					currentTimeInMS,
+				// added minimum of one day
+				daysSinceLastPurchase = Math.max(
+					1,
+					getDaysBetweenDates(dateCreated.toMillis(), currentTimeInMS),
 				);
 
 				// do the calculateEstimate docs actually require default val of prevEst to be 14 if none supplied? if so, why 14 and not 7?

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -24,7 +24,6 @@ export function ListItem({
 		// only update item when the checkbox has been checked. Don't update when the page just loaded and "isPurchased" is changed accordingly
 		if (isChecked !== isPurchased) {
 			// currently: checked item unchecks quickly and rechecks (re-rendering?) - uncontrolled total purchases incrementation
-			// call currentDate, currentTime inside
 			updateItem(listToken, {
 				itemId: itemId,
 				isChecked: isPurchased,
@@ -35,7 +34,7 @@ export function ListItem({
 				totalPurchases: totalPurchases,
 			});
 		}
-	}, [isPurchased, isChecked, itemId, listToken, dateNextPurchased]);
+	}, [isPurchased, isChecked, itemId, listToken]); //had dateNextPurchased
 
 	useEffect(() => {
 		if (dateLastPurchased) {

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -28,14 +28,11 @@ export function ListItem({
 			let currentDate = getFutureDate(0);
 			let currentTimeInMS = new Date().getTime();
 
-			// console.log(`current Time ${currentTimeInMS}`)
-			// console.log(`dateLastPurchased ${dateLastPurchased}`)
-
 			let daysSinceLastPurchase;
 			let prevEst;
 			if (!dateLastPurchased) {
 				daysSinceLastPurchase = 0;
-				// use date created instead for prevEst param?
+				// use date created if no record of previous buys/null
 				prevEst = getDaysBetweenDates(
 					dateCreated.toMillis(),
 					dateNextPurchased.toMillis(),
@@ -50,6 +47,8 @@ export function ListItem({
 					dateNextPurchased.toMillis(),
 				); //any way to grab the days elapsed sooner?(7/14/21)
 			}
+			// console.log(`current Time ${currentTimeInMS}`)
+			// console.log(`dateLastPurchased ${dateLastPurchased}`)
 
 			let daysToNextPurchase = calculateEstimate(
 				prevEst,
@@ -58,15 +57,13 @@ export function ListItem({
 			); //returns integer - days to next purchase.
 			// ^ turn into date
 			let actualDateNextPurchased = getFutureDate(daysToNextPurchase);
-			console.log(`actual date next purchase ${actualDateNextPurchased}`);
-			// dateNextPurchased: //will we reassign at some point?
-			// does not go into Firebase
+			// console.log(`actual date next purchase ${actualDateNextPurchased}`);
 
 			updateItem(listToken, {
 				itemId: itemId,
 				isChecked: isPurchased,
 				currentDate: currentDate,
-				dateNextPurchased: actualDateNextPurchased,
+				dateNextPurchased: actualDateNextPurchased, //reassigned and sent to firebase
 			});
 		}
 	}, [isPurchased, isChecked, itemId, listToken]);

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -32,15 +32,14 @@ export function ListItem({
 				currentTimeInMS,
 			); //date is in ms, returns daysSinceLastPurchase
 			let prevEst = getDaysBetweenDates(dateLastPurchased, dateNextPurchased); //any way to grab the days elapsed sooner?(7/14/21)
-			console.log(dateNextPurchased);
 			let daysToNextPurchase = calculateEstimate(
 				prevEst,
 				daysSinceLastPurchase,
 				totalPurchases,
 			); //returns integer - days to next purchase.
 			// ^ turn into date
-			let actualDateNextPurchase = getFutureDate(daysToNextPurchase);
-			console.log(`actual date next purchase ${actualDateNextPurchase}`);
+			let actualDateNextPurchased = getFutureDate(daysToNextPurchase);
+			console.log(`actual date next purchase ${actualDateNextPurchased}`);
 			// dateNextPurchased: //will we reassign at some point?
 			// does not go into Firebase
 
@@ -48,6 +47,7 @@ export function ListItem({
 				itemId: itemId,
 				isChecked: isPurchased,
 				currentDate: currentDate,
+				dateNextPurchased: actualDateNextPurchased,
 			});
 		}
 	}, [isPurchased, isChecked, itemId, listToken]);

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -26,8 +26,8 @@ export function ListItem({
 		// only update item when the checkbox has been checked. Don't update when the page just loaded and "isPurchased" is changed accordingly
 		if (isChecked !== isPurchased) {
 			let currentDate = getFutureDate(0);
-			let currentTimeInMS = new Date().getTime();
 
+			let currentTimeInMS = new Date().getTime();
 			let daysSinceLastPurchase;
 			let prevEst;
 			if (!dateLastPurchased) {
@@ -49,13 +49,11 @@ export function ListItem({
 			}
 			// console.log(`current Time ${currentTimeInMS}`)
 			// console.log(`dateLastPurchased ${dateLastPurchased}`)
-
 			let daysToNextPurchase = calculateEstimate(
 				prevEst,
 				daysSinceLastPurchase,
 				totalPurchases,
-			); //returns integer - days to next purchase.
-			// ^ turn into date
+			); //returns integer - days to next purchase. Then turn into date
 			let actualDateNextPurchased = getFutureDate(daysToNextPurchase);
 			// console.log(`actual date next purchase ${actualDateNextPurchased}`);
 

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -2,9 +2,7 @@ import { useState, useEffect } from 'react';
 
 import { updateItem } from '../api/firebase';
 
-import { getFutureDate, getDaysBetweenDates } from '../utils';
-
-import { calculateEstimate } from '@the-collab-lab/shopping-list-utils/dist/calculateEstimate';
+import { getFutureDate } from '../utils';
 
 import './ListItem.css';
 
@@ -25,64 +23,19 @@ export function ListItem({
 	useEffect(() => {
 		// only update item when the checkbox has been checked. Don't update when the page just loaded and "isPurchased" is changed accordingly
 		if (isChecked !== isPurchased) {
-			let currentDate = getFutureDate(0);
-
-			let currentTimeInMS = new Date().getTime();
-			let daysSinceLastPurchase;
-			let prevEst;
-			if (!dateLastPurchased) {
-				// daysSinceLastPurchase = 0;  //original approach different from calculateEstimate docs
-
-				// following calculateEstimate docs, uses date created if no record of previous buys/null
-				// added minimum of one day
-				daysSinceLastPurchase = Math.max(
-					1,
-					getDaysBetweenDates(dateCreated.toMillis(), currentTimeInMS),
-				);
-
-				// do the calculateEstimate docs actually require default val of prevEst to be 14 if none supplied? if so, why 14 and not 7?
-				// per calcEstimate, it should be fine to pass prevEst as-is (leave undefined, commenting out lines 45-47) and it should default to 14.
-				prevEst = getDaysBetweenDates(
-					dateCreated.toMillis(),
-					dateNextPurchased.toMillis(),
-				);
-			} else {
-				daysSinceLastPurchase = getDaysBetweenDates(
-					dateLastPurchased.toMillis(),
-					currentTimeInMS,
-				); //date is in ms, returns daysSinceLastPurchase
-				prevEst = getDaysBetweenDates(
-					dateLastPurchased.toMillis(),
-					dateNextPurchased.toMillis(),
-				); //any way to grab the days elapsed sooner?(7/14/21)
-			}
-			console.log(`current Time ${currentTimeInMS}`);
-			console.log(`dateLastPurchased ${dateLastPurchased}`);
-			let daysToNextPurchase = calculateEstimate(
-				prevEst, // is 14 supposed to be default if none? i.e., prevEst || 14 here?
-				daysSinceLastPurchase,
-				// why do calculateEstimate docs prefer to set this as  number of days since the item was added to the list (if no previous purchase)?
-				//https://github.com/the-collab-lab/shopping-list-utils/blob/main/src/calculateEstimate/index.ts
-				totalPurchases,
-			); //returns integer - days to next purchase. Then turn into date
-			let actualDateNextPurchased = getFutureDate(daysToNextPurchase);
-
-			// this is what should come from firebase
-			let initialDateNext = dateNextPurchased.toDate();
-
-			// current issue: freq skews hard towards latest purchase - bug or just misuse of app?
-			console.log(
-				`actual date next purchase ${actualDateNextPurchased}; total purchse number ${totalPurchases}; initial date next from firebase ${initialDateNext}`,
-			);
-
+			// currently: checked item unchecks quickly and rechecks (re-rendering?) - uncontrolled total purchases incrementation
+			// call currentDate, currentTime inside
 			updateItem(listToken, {
 				itemId: itemId,
 				isChecked: isPurchased,
-				currentDate: currentDate,
-				dateNextPurchased: actualDateNextPurchased, //reassigned and sent to firebase
+				dateCreated: dateCreated,
+				currentDate: getFutureDate(0),
+				currentTime: new Date().getTime(),
+				dateNextPurchased: dateNextPurchased, //reassigned inside the function - this passes initial dNP
+				totalPurchases: totalPurchases,
 			});
 		}
-	}, [isPurchased, isChecked, itemId, listToken]);
+	}, [isPurchased, isChecked, itemId, listToken, dateNextPurchased]);
 
 	useEffect(() => {
 		if (dateLastPurchased) {

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -27,11 +27,24 @@ export function ListItem({
 			let currentDate = getFutureDate(0);
 			let currentTimeInMS = new Date().getTime();
 
-			let daysSinceLastPurchase = getDaysBetweenDates(
-				dateLastPurchased,
-				currentTimeInMS,
-			); //date is in ms, returns daysSinceLastPurchase
-			let prevEst = getDaysBetweenDates(dateLastPurchased, dateNextPurchased); //any way to grab the days elapsed sooner?(7/14/21)
+			// console.log(`current Time ${currentTimeInMS}`)
+			// console.log(`dateLastPurchased ${dateLastPurchased}`)
+
+			let daysSinceLastPurchase;
+			let prevEst;
+			if (!dateLastPurchased) {
+				daysSinceLastPurchase = 0;
+			} else {
+				daysSinceLastPurchase = getDaysBetweenDates(
+					dateLastPurchased.toMillis(),
+					currentTimeInMS,
+				); //date is in ms, returns daysSinceLastPurchase
+				prevEst = getDaysBetweenDates(
+					dateLastPurchased.toMillis(),
+					dateNextPurchased.toMillis(),
+				); //any way to grab the days elapsed sooner?(7/14/21)
+			}
+
 			let daysToNextPurchase = calculateEstimate(
 				prevEst,
 				daysSinceLastPurchase,

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -34,7 +34,7 @@ export function ListItem({
 				totalPurchases: totalPurchases,
 			});
 		}
-	}, [isPurchased, isChecked, itemId, listToken]); //had dateNextPurchased
+	}, [isPurchased, itemId, listToken]); //had dateNextPurchased, isChecked
 
 	useEffect(() => {
 		if (dateLastPurchased) {

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -13,9 +13,10 @@ export function getFutureDate(offset) {
 
 export function getDaysBetweenDates(dateLastPurchased, currentTime) {
 	// param both in ms
-	const daysSinceLastPurchase = Math.abs(
+	const daysSinceLastPurchase = Math.round(
 		(currentTime - dateLastPurchased) / ONE_DAY_IN_MILLISECONDS,
 	);
+	console.log(daysSinceLastPurchase);
 	// do calc to get daysSinceLastTransaction
 	return daysSinceLastPurchase;
 }

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -11,10 +11,10 @@ export function getFutureDate(offset) {
 	return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
 }
 
-export function getDaysBetweenDates(dateLastPurchased, currentTime) {
+export function getDaysBetweenDates(startTime, currentTime) {
 	// param both in ms
 	const daysSinceLastPurchase = Math.round(
-		(currentTime - dateLastPurchased) / ONE_DAY_IN_MILLISECONDS,
+		(currentTime - startTime) / ONE_DAY_IN_MILLISECONDS,
 	);
 	console.log(daysSinceLastPurchase);
 	// do calc to get daysSinceLastTransaction

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -10,3 +10,12 @@ const ONE_DAY_IN_MILLISECONDS = 86400000;
 export function getFutureDate(offset) {
 	return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
 }
+
+export function getDaysBetweenDates(dateLastPurchased, currentTime) {
+	// param both in ms
+	const daysSinceLastPurchase = Math.abs(
+		(currentTime - dateLastPurchased) / ONE_DAY_IN_MILLISECONDS,
+	);
+	// do calc to get daysSinceLastTransaction
+	return daysSinceLastPurchase;
+}

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -16,7 +16,5 @@ export function getDaysBetweenDates(startTime, currentTime) {
 	const daysSinceLastPurchase = Math.round(
 		(currentTime - startTime) / ONE_DAY_IN_MILLISECONDS,
 	);
-	console.log(daysSinceLastPurchase);
-	// do calc to get daysSinceLastTransaction
 	return daysSinceLastPurchase;
 }

--- a/src/utils/validateStrings.js
+++ b/src/utils/validateStrings.js
@@ -1,0 +1,9 @@
+export const isEmpty = (itemName) => cleanup(itemName) === '';
+export const isDuplicate = (itemName, data) =>
+	data.some(({ name }) => cleanup(name) === cleanup(itemName));
+
+const cleanup = (inputString) =>
+	inputString
+		.toLowerCase()
+		.trim()
+		.replace(/[\W_-]/g, '');

--- a/src/utils/validateStrings.js
+++ b/src/utils/validateStrings.js
@@ -1,8 +1,15 @@
-export const isEmpty = (itemName) => cleanup(itemName) === '';
+/**
+ * Checks if an empty string of any length has been passed in
+ * @param {string} itemName
+ * @returns {boolean}
+ */
+export const isEmpty = (itemName) =>
+	typeof itemName !== 'string' || itemName.trim().length === 0;
+
 export const isDuplicate = (itemName, data) =>
 	data.some(({ name }) => cleanup(name) === cleanup(itemName));
 
-const cleanup = (inputString) =>
+export const cleanup = (inputString) =>
 	inputString
 		.toLowerCase()
 		.trim()

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { isEmpty, isDuplicate } from '../utils/validateStrings';
 import { addItem } from '../api/firebase';
 
 const defaultItem = { itemName: '', daysUntilNextPurchase: 7 };
@@ -20,36 +21,28 @@ export function AddItem({ data, listToken }) {
 		setItem({ ...item, [e.target.name]: updateVal });
 	};
 
-	const cleanup = (inputString) => {
-		return inputString.toLowerCase().trim().replace(/[\W]/g, '');
-	};
-
-	const checkForEmpty = (itemName) => {
-		// defer cleanup to this step so 'user’s original input is saved in the database'
-		if (cleanup(itemName) === '') {
-			setStatus(`Can not add an empty item`);
+	const isInvalid = (name) => {
+		if (isEmpty(name)) {
+			setStatus('Can not add an empty item');
+			setItem(defaultItem);
+			return true;
 		}
-	};
-
-	const checkForDuplicate = (itemName) => {
-		data.forEach((item) => {
-			if (cleanup(item.name) === cleanup(itemName)) {
-				setStatus(`This item has already been added`);
-			}
-		});
+		if (isDuplicate(name, data)) {
+			setStatus('This item has already been added');
+			setItem(defaultItem);
+			return true;
+		}
+		return false;
 	};
 
 	const addItemToDatabase = (e) => {
 		e.preventDefault();
+		if (isInvalid(item.itemName)) return;
 
-		checkForEmpty(item.itemName);
-
-		checkForDuplicate(item.itemName);
-
-		// addItem(listToken, item)
-		// 	.then(() => setStatus('Item added successfully!'))
-		// 	.then(() => setItem(defaultItem))
-		// 	.catch(() => setStatus('Item could not be added.'));
+		addItem(listToken, item)
+			.then(() => setStatus('Item added successfully!'))
+			.then(() => setItem(defaultItem))
+			.catch(() => setStatus('Item could not be added.'));
 	};
 
 	return (

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { addItem } from '../api/firebase';
 
 const defaultItem = { itemName: '', daysUntilNextPurchase: 7 };
-export function AddItem({ listToken }) {
+export function AddItem({ data, listToken }) {
 	const [item, setItem] = useState(defaultItem);
 	const [status, setStatus] = useState('');
 
@@ -20,13 +20,36 @@ export function AddItem({ listToken }) {
 		setItem({ ...item, [e.target.name]: updateVal });
 	};
 
+	const cleanup = (inputString) => {
+		return inputString.toLowerCase().trim().replace(/[\W]/g, '');
+	};
+
+	const checkForEmpty = (itemName) => {
+		// defer cleanup to this step so 'user’s original input is saved in the database'
+		if (cleanup(itemName) === '') {
+			setStatus(`Can not add an empty item`);
+		}
+	};
+
+	const checkForDuplicate = (itemName) => {
+		data.forEach((item) => {
+			if (cleanup(item.name) === cleanup(itemName)) {
+				setStatus(`This item has already been added`);
+			}
+		});
+	};
+
 	const addItemToDatabase = (e) => {
 		e.preventDefault();
 
-		addItem(listToken, item)
-			.then(() => setStatus('Item added successfully!'))
-			.then(() => setItem(defaultItem))
-			.catch(() => setStatus('Item could not be added.'));
+		checkForEmpty(item.itemName);
+
+		checkForDuplicate(item.itemName);
+
+		// addItem(listToken, item)
+		// 	.then(() => setStatus('Item added successfully!'))
+		// 	.then(() => setItem(defaultItem))
+		// 	.catch(() => setStatus('Item could not be added.'));
 	};
 
 	return (

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -80,20 +80,22 @@ export function List({ data, listToken }) {
 						name,
 						id,
 						isChecked,
+						dateCreated,
 						dateLastPurchased,
 						dateNextPurchased,
 						totalPurchases,
 					}) => (
 						<ListItem
-							name={name}
 							key={id}
 							itemId={id}
 							listToken={listToken}
-							isChecked={isChecked}
+							// refactor spread syntax?
+							dateCreated={dateCreated}
 							dateLastPurchased={dateLastPurchased}
 							dateNextPurchased={dateNextPurchased}
+							isChecked={isChecked}
+							name={name}
 							totalPurchases={totalPurchases}
-							// refactor spread syntax?
 						/>
 					),
 				)}

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -81,6 +81,7 @@ export function List({ data, listToken }) {
 						listToken={listToken}
 						key={item.id}
 						itemId={item.id}
+						// some error?
 					/>
 				))}
 			</ul>

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -75,35 +75,14 @@ export function List({ data, listToken }) {
 			)}
 
 			<ul>
-				{filterList(data).map(
-					({
-						name,
-						id,
-						isChecked,
-						dateCreated,
-						dateLastPurchased,
-						dateNextPurchased,
-						totalPurchases,
-					}) => (
-						// item, listToken
-						<ListItem
-							// key={item.id}
-							// itemId={item.id}
-
-							listToken={listToken}
-							key={id}
-							itemId={id}
-							// refactor spread syntax?
-							// {...item}
-							dateCreated={dateCreated}
-							dateLastPurchased={dateLastPurchased}
-							dateNextPurchased={dateNextPurchased}
-							isChecked={isChecked}
-							name={name}
-							totalPurchases={totalPurchases}
-						/>
-					),
-				)}
+				{filterList(data).map((item) => (
+					<ListItem
+						{...item}
+						listToken={listToken}
+						key={item.id}
+						itemId={item.id}
+					/>
+				))}
 			</ul>
 		</>
 	);

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -85,11 +85,16 @@ export function List({ data, listToken }) {
 						dateNextPurchased,
 						totalPurchases,
 					}) => (
+						// item, listToken
 						<ListItem
+							// key={item.id}
+							// itemId={item.id}
+
+							listToken={listToken}
 							key={id}
 							itemId={id}
-							listToken={listToken}
 							// refactor spread syntax?
+							// {...item}
 							dateCreated={dateCreated}
 							dateLastPurchased={dateLastPurchased}
 							dateNextPurchased={dateNextPurchased}

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -75,16 +75,20 @@ export function List({ data, listToken }) {
 			)}
 
 			<ul>
-				{filterList(data).map(({ name, id, isChecked, dateLastPurchased }) => (
-					<ListItem
-						name={name}
-						key={id}
-						itemId={id}
-						listToken={listToken}
-						isChecked={isChecked}
-						dateLastPurchased={dateLastPurchased}
-					/>
-				))}
+				{filterList(data).map(
+					({ name, id, isChecked, dateLastPurchased, totalPurchases }) => (
+						<ListItem
+							name={name}
+							key={id}
+							itemId={id}
+							listToken={listToken}
+							isChecked={isChecked}
+							dateLastPurchased={dateLastPurchased}
+							totalPurchases={totalPurchases}
+							// refactor spread syntax?
+						/>
+					),
+				)}
 			</ul>
 		</>
 	);

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -81,7 +81,6 @@ export function List({ data, listToken }) {
 						listToken={listToken}
 						key={item.id}
 						itemId={item.id}
-						// some error?
 					/>
 				))}
 			</ul>

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -76,7 +76,14 @@ export function List({ data, listToken }) {
 
 			<ul>
 				{filterList(data).map(
-					({ name, id, isChecked, dateLastPurchased, totalPurchases }) => (
+					({
+						name,
+						id,
+						isChecked,
+						dateLastPurchased,
+						dateNextPurchased,
+						totalPurchases,
+					}) => (
 						<ListItem
 							name={name}
 							key={id}
@@ -84,6 +91,7 @@ export function List({ data, listToken }) {
 							listToken={listToken}
 							isChecked={isChecked}
 							dateLastPurchased={dateLastPurchased}
+							dateNextPurchased={dateNextPurchased}
 							totalPurchases={totalPurchases}
 							// refactor spread syntax?
 						/>

--- a/tests/validateStrings.test.jsx
+++ b/tests/validateStrings.test.jsx
@@ -1,0 +1,32 @@
+import { isEmpty, isDuplicate, cleanup } from '../src/utils/validateStrings';
+
+describe('isEmpty function', () => {
+	it('Returns true when passed any empty string', () => {
+		const empty = ['', '  ', '          '];
+
+		empty.forEach((input) => {
+			expect(isEmpty(input)).toBeTruthy();
+		});
+	});
+
+	it('Returns true when not passed correct type or defined value', () => {
+		const notStrings = [
+			98,
+			['haha', 'fooled you'],
+			{ object: 'I am an object' },
+			undefined,
+		];
+
+		notStrings.forEach((val) => {
+			expect(isEmpty(val)).toBeTruthy();
+		});
+	});
+
+	it('Returns false when passed any non-empty string', () => {
+		const nonEmpty = ['sdf', ' / ', 'A', '-', '@', '12930'];
+
+		nonEmpty.forEach((input) => {
+			expect(isEmpty(input)).toBeFalsy();
+		});
+	});
+});


### PR DESCRIPTION
## Description

Added logic (in .utils, updateItem() in `firebase.js`, and inside the useEffect in `ListItem.js`) so that when the user checks off an item as purchased, the app can calculate and store a guess for when the item should be purchased next. 

The user does not currently see any changes to the UI, but the dateNextPurchased is updated in Firebase to enable future functionality.

### Considerations
- Avoiding infinite loop or double-counting: The app behavior seems to vary despite running checks on the same code/sub-branches. Excluding `isChecked` from the first useEffect deps inside `ListItem.js` seems to remove all unexpected behavior, but inclusion of `isChecked` in deps seems to work fine on other browser/device? **Needs further confirmation in this review**. 
- Based on `calculateEstimate` docs, prevEst (previous estimate) is left undefined when no dateLastPurchased is on record. 
- As well, daysSinceLastPurchase is calculated as time elapsed since item added (dateCreated) and current time. A buffer of minimum 1 day was added to avoid a recommendation of immediate/same-day prediction based on the current calculations.
- Inconsistent reference at times in the docs to the "days elapsed" param - would be open to standardizing to daysSinceLastTransaction (since that is more inclusive of the interval values passed for that param).

## Related Issue

Closes #10 

## Acceptance Criteria

- [x] A `getDaysBetweenDates` function is exported from `utils/dates.js`  and imported into `api/firebase.js`
  - [x] This function takes two JavaScript Dates and return the number of days that have passed between them
- [x] When the user purchases an item, the item’s `dateNextPurchased` property is calculated using the `calculateEstimate` function and saved to the Firestore database
  - [x] `dateNextPurchased` is saved as **a date**, not a number
## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates
No UI changes.

## Testing Steps / QA Criteria
1. Pull and check out `yh-hy-estimatePurchaseDate-10` and run with `npm start`. In a separate window, open the [Firebase console](https://console.firebase.google.com/u/1/project/tcl-46-smart-shopping-list/firestore/data/~2Fbean%20selma%20wade~2FAzUvhs9KvR4L9PePSORF). Join `my test list` and in Firebase, navigate to an item you recognize from the app List page for the next steps.
2.  Check off the item in the app and see the updates to the Firebase doc in real time for dateLastPurchased, dateNextPurchased, and totalPurchases.
  - If totalPurchases is less than 2, the dateNextPurchased should correspond to the difference between dateLastPurchased and dateCreated. If totalPurchases is greater than 2, dateNextPurchased should provide a date that reflects the difference between dateLastPurchased and the previous (pre-update) dateNextPurchased estimate.
  - totalPurchases should increment by 1 only each time isChecked is true, and isChecked status should be synced to the live app view for that item. 