### PR TITLE
Fix failing `App.jsx` test

### DIFF
--- a/tests/App.test.jsx
+++ b/tests/App.test.jsx
@@ -1,6 +1,11 @@
 import { render } from '@testing-library/react';
 import { App } from '../src/App';
+import { BrowserRouter as Router } from 'react-router-dom';
 
 it('renders without crashing', () => {
-	render(<App />);
+	render(
+		<Router>
+			<App />
+		</Router>,
+	);
 });


### PR DESCRIPTION
## Description

Wrapped the `<App/>` rendered in `App.test.jsx` in a `<Router>` component in order to fix the failing test prompting a wrapped `useNavigate()` hook.

## Related Issue

Closes #30 

## Acceptance Criteria

<!-- Include AC from the Github issue -->

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓   | :bug: Bug fix              |
|    | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

![image](https://user-images.githubusercontent.com/77255525/184787825-7755f5e0-589f-4446-9194-e7476a0bbccb.png)

### After

![image](https://user-images.githubusercontent.com/77255525/184787801-500a9634-e357-4aab-bf2e-d94a10333251.png)

## Testing Steps / QA Criteria

Pull down branch and run `npm run test` to see that all our tests pass now~ Hooray.
