### PR TITLE
Create Summary page for user to see an overview of purchases

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,6 +26,11 @@ export function App() {
 		'tcl-shopping-list-token',
 	);
 
+	const [goals, setGoals] = useStateWithStorage(
+		'Set a goal for your shopping habits!',
+		'tcl-shopping-list-goals',
+	); //these should be drawn from association with userID, if we build out user database
+
 	useEffect(() => {
 		if (!listToken) return;
 		else {
@@ -71,7 +76,10 @@ export function App() {
 					path="/add-item"
 					element={<AddItem data={data} listToken={listToken} />}
 				/>
-				<Route path="/summary" element={<Summary data={data} />} />
+				<Route
+					path="/summary"
+					element={<Summary data={data} goal={[goals, setGoals]} />}
+				/>
 			</Route>
 		</Routes>
 	);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Routes, Route, useNavigate } from 'react-router-dom';
 
-import { AddItem, Home, Layout, List } from './views';
+import { AddItem, Home, Layout, List, Summary } from './views';
 
 import { getItemData, streamListItems } from './api';
 import { useStateWithStorage } from './utils';
@@ -71,6 +71,7 @@ export function App() {
 					path="/add-item"
 					element={<AddItem data={data} listToken={listToken} />}
 				/>
+				<Route path="/summary" element={<Summary data={data} />} />
 			</Route>
 		</Routes>
 	);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,11 +26,6 @@ export function App() {
 		'tcl-shopping-list-token',
 	);
 
-	const [goals, setGoals] = useStateWithStorage(
-		'Set a goal for your shopping habits!',
-		'tcl-shopping-list-goals',
-	); //these should be drawn from association with userID, if we build out user database
-
 	useEffect(() => {
 		if (!listToken) return;
 		else {
@@ -76,10 +71,7 @@ export function App() {
 					path="/add-item"
 					element={<AddItem data={data} listToken={listToken} />}
 				/>
-				<Route
-					path="/summary"
-					element={<Summary data={data} goal={[goals, setGoals]} />}
-				/>
+				<Route path="/summary" element={<Summary data={data} />} />
 			</Route>
 		</Routes>
 	);

--- a/src/components/Goals.jsx
+++ b/src/components/Goals.jsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+import { isEmpty } from '../utils/validateStrings';
+
+export function Goals({ updateGoals, goals, isDisabled, editGoals }) {
+	return (
+		// componentize here and multList?
+		// also consider building out into array so that multiple goals can be formatted nicely in list.
+		<>
+			<form onSubmit={editGoals}>
+				<input
+					readOnly={isDisabled}
+					style={
+						isDisabled
+							? {
+									outline: 'none',
+									borderWidth: 0,
+									width: '100%',
+									backgroundColor: 'transparent',
+									marginBottom: '1rem',
+							  }
+							: {
+									backgroundColor: 'white',
+									borderWidth: '1px',
+									width: '100%',
+									marginBottom: '1rem',
+							  }
+					}
+					onChange={updateGoals}
+					value={goals}
+				/>
+				<button
+					type="submit"
+					disabled={isEmpty(goals)} //prevent exit without content
+				>
+					{isDisabled ? 'Update' : 'Save'}
+				</button>
+			</form>
+		</>
+	);
+}

--- a/src/components/Goals.jsx
+++ b/src/components/Goals.jsx
@@ -1,7 +1,22 @@
 import { useState } from 'react';
+import { useStateWithStorage } from '../utils';
+
 import { isEmpty } from '../utils/validateStrings';
 
-export function Goals({ updateGoals, goals, isDisabled, editGoals }) {
+export function Goals() {
+	const [goals, setGoals] = useStateWithStorage(
+		'Set a goal for your shopping habits!',
+		'tcl-shopping-list-goals',
+	); //these should be drawn from association with userID, if we build out user database
+
+	// as noted in Goals - componetize here and fr multList approach
+	const [isDisabled, setIsDisabled] = useState(true);
+
+	const editGoals = (e) => {
+		e.preventDefault();
+		setIsDisabled(!isDisabled);
+	};
+
 	return (
 		// componentize here and multList?
 		// also consider building out into array so that multiple goals can be formatted nicely in list.
@@ -25,7 +40,7 @@ export function Goals({ updateGoals, goals, isDisabled, editGoals }) {
 									marginBottom: '1rem',
 							  }
 					}
-					onChange={updateGoals}
+					onChange={(e) => setGoals(e.target.value)}
 					value={goals}
 				/>
 				<button

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -21,6 +21,9 @@ export function Layout() {
 				<NavLink to="/add-item" className="Nav-link">
 					Add Item
 				</NavLink>
+				<NavLink to="/summary" className="Nav-link">
+					Summary
+				</NavLink>
 			</nav>
 		</div>
 	);

--- a/src/views/Summary.jsx
+++ b/src/views/Summary.jsx
@@ -48,7 +48,7 @@ export function Summary({ data }) {
 
 	return (
 		<div className="Summary">
-			{purchased ? (
+			{purchased.length ? (
 				<div>
 					<h2>Your purchase history to date</h2>
 					<h3>Top 5 purchases by frequency:</h3>
@@ -79,7 +79,7 @@ export function Summary({ data }) {
 				<p>No purchase history found.</p>
 			)}
 
-			{mostNeglectedItems ? (
+			{mostNeglectedItems.length ? ( //if not length, it still shows heading below because the variable exists as empty array
 				<>
 					<h3>Did you forget about these?</h3>
 
@@ -92,7 +92,7 @@ export function Summary({ data }) {
 					))}
 				</>
 			) : (
-				"You've bought everything on your list at least once! Good job."
+				<h3>You've bought everything on your list at least once! Good job.</h3>
 			)}
 
 			<h2>Personal Goals</h2>

--- a/src/views/Summary.jsx
+++ b/src/views/Summary.jsx
@@ -1,23 +1,29 @@
 import { useState, useMemo } from 'react';
-import { getDaysBetweenDates } from '../utils';
+import { getDaysBetweenDates, useStateWithStorage } from '../utils';
 import { comparePurchaseUrgency } from '../utils/item';
+import { Goals } from '../components/Goals';
 
 export function Summary({ data }) {
-	const [goals, setGoals] = useState(''); //these should be drawn from association with userID, if we build out user database
+	// as noted in Goals - componetize here and fr multList approach
+	const [isDisabled, setIsDisabled] = useState(true);
 
-	/**
-    Summary of data keys - to remove on finalization
-  
-	itemId,
-	name,
-	isChecked,
-	dateCreated,
-	dateLastPurchased,
-	dateNextPurchased,
-	totalPurchases,
-	refTime,
-	daysToNext,
-    */
+	const [goals, setGoals] = useStateWithStorage(
+		'Set a goal for your shopping habits!',
+		'tcl-shopping-list-goals',
+	); //these should be drawn from association with userID, if we build out user database
+
+	const updateGoals = (e) => {
+		const newGoal = e.target.value;
+		setGoals(newGoal);
+	};
+
+	const editGoals = (e) => {
+		e.preventDefault();
+		if (!isDisabled) {
+			updateGoals(e);
+		}
+		setIsDisabled(!isDisabled);
+	};
 
 	//memoize below?
 	const getPurchased = (array) =>
@@ -113,7 +119,12 @@ export function Summary({ data }) {
 			)}
 
 			<h2>Personal Goals</h2>
-			{goals ? <p>{goals}</p> : 'Set some goals for your shopping habits!'}
+			<Goals
+				goals={goals}
+				isDisabled={isDisabled}
+				updateGoals={updateGoals}
+				editGoals={editGoals}
+			/>
 		</div>
 	);
 }

--- a/src/views/Summary.jsx
+++ b/src/views/Summary.jsx
@@ -1,24 +1,9 @@
 import { useState, useMemo } from 'react';
-import { getDaysBetweenDates, useStateWithStorage } from '../utils';
+import { getDaysBetweenDates } from '../utils';
 import { comparePurchaseUrgency } from '../utils/item';
 import { Goals } from '../components/Goals';
 
 export function Summary({ data, goal }) {
-	// as noted in Goals - componetize here and fr multList approach
-	const [isDisabled, setIsDisabled] = useState(true);
-
-	const [goals, setGoals] = goal;
-
-	const updateGoals = (e) => {
-		const newGoal = e.target.value;
-		setGoals(newGoal);
-	};
-
-	const editGoals = (e) => {
-		e.preventDefault();
-		setIsDisabled(!isDisabled);
-	};
-
 	//memoize below?
 	const getPurchased = (array) =>
 		array.filter((item) => item.dateLastPurchased); //purchased at least once, not null value
@@ -113,12 +98,7 @@ export function Summary({ data, goal }) {
 			)}
 
 			<h2>Personal Goals</h2>
-			<Goals
-				goals={goals}
-				isDisabled={isDisabled}
-				updateGoals={updateGoals}
-				editGoals={editGoals}
-			/>
+			<Goals />
 		</div>
 	);
 }

--- a/src/views/Summary.jsx
+++ b/src/views/Summary.jsx
@@ -48,10 +48,10 @@ export function Summary({ data }) {
 
 	return (
 		<div className="Summary">
-			{purchased.length ? (
+			{purchased ? (
 				<div>
 					<h2>Your purchase history to date</h2>
-					<h3>Five most frequently purchased items:</h3>
+					<h3>Top 5 purchases by frequency:</h3>
 					<ol>
 						{fiveMostPurchased.map((item) => (
 							<li key={item.itemId}>
@@ -60,7 +60,7 @@ export function Summary({ data }) {
 						))}
 					</ol>
 
-					<h3>Five most recent purchases:</h3>
+					<h3>5 most recent purchases:</h3>
 					<ol>
 						{fiveMostRecentPurchases.map((item) => (
 							<li key={item.itemId}>
@@ -74,21 +74,27 @@ export function Summary({ data }) {
 							</li>
 						))}
 					</ol>
-
-					<h3>Item(s) you may have forgotten about:</h3>
-					<ul>
-						{mostNeglectedItems.map((item) => (
-							<li key={item.itemId}>
-								The item "{item.name}" is{' '}
-								{getDaysBetweenDates(item.refTime, currentTime)} days old and
-								was never purchased.
-							</li> //ambivalent about this one and also where the logic is
-						))}
-					</ul>
 				</div>
 			) : (
 				<p>No purchase history found.</p>
 			)}
+
+			{mostNeglectedItems ? (
+				<>
+					<h3>Did you forget about these?</h3>
+
+					{mostNeglectedItems.map((item) => (
+						<div key={item.itemId}>
+							The item "{item.name}" is{' '}
+							{getDaysBetweenDates(item.refTime, currentTime)} days old and was
+							never purchased.
+						</div> //ambivalent about this one and also where the logic is
+					))}
+				</>
+			) : (
+				"You've bought everything on your list at least once! Good job."
+			)}
+
 			<h2>Personal Goals</h2>
 			{goals ? <p>{goals}</p> : 'Set some goals for your shopping habits!'}
 		</div>

--- a/src/views/Summary.jsx
+++ b/src/views/Summary.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo } from 'react';
 import { getDaysBetweenDates, useStateWithStorage } from '../utils';
 import { comparePurchaseUrgency } from '../utils/item';
 import { Goals } from '../components/Goals';
@@ -21,10 +21,6 @@ export function Summary({ data, goal }) {
 		}
 		setIsDisabled(!isDisabled);
 	};
-
-	useEffect(() => {
-		console.log(data.map((item) => Object.entries(item)));
-	});
 
 	//memoize below?
 	const getPurchased = (array) =>

--- a/src/views/Summary.jsx
+++ b/src/views/Summary.jsx
@@ -52,37 +52,36 @@ export function Summary({ data }) {
 				<div>
 					<h2>Your purchase history to date</h2>
 					<h3>Five most frequently purchased items:</h3>
-					<ul>
+					<ol>
 						{fiveMostPurchased.map((item) => (
 							<li key={item.itemId}>
 								{item.name}: bought {item.totalPurchases} times
 							</li>
 						))}
-					</ul>
+					</ol>
 
 					<h3>Five most recent purchases:</h3>
-					<ul>
+					<ol>
 						{fiveMostRecentPurchases.map((item) => (
 							<li key={item.itemId}>
 								{item.name}: bought on{' '}
-								{item.dateLastPurchased
-									.toDate()
-									.toLocaleDateString('en-us', {
-										weekday: 'long',
-										year: 'numeric',
-										month: 'short',
-										day: 'numeric',
-									})}
+								{item.dateLastPurchased.toDate().toLocaleDateString('en-us', {
+									weekday: 'long',
+									year: 'numeric',
+									month: 'short',
+									day: 'numeric',
+								})}
 							</li>
 						))}
-					</ul>
+					</ol>
 
 					<h3>Item(s) you may have forgotten about:</h3>
 					<ul>
 						{mostNeglectedItems.map((item) => (
 							<li key={item.itemId}>
-								{item.name} is {getDaysBetweenDates(item.refTime, currentTime)}{' '}
-								days old and was never purchased.
+								The item "{item.name}" is{' '}
+								{getDaysBetweenDates(item.refTime, currentTime)} days old and
+								was never purchased.
 							</li> //ambivalent about this one and also where the logic is
 						))}
 					</ul>

--- a/src/views/Summary.jsx
+++ b/src/views/Summary.jsx
@@ -88,7 +88,7 @@ export function Summary({ data }) {
 						))}
 					</ol>
 
-					{mostNeglectedItem.length ? ( //need to hide placeholder item
+					{mostNeglectedItem.length ? (
 						<>
 							<h3>Did you forget about these?</h3>
 

--- a/src/views/Summary.jsx
+++ b/src/views/Summary.jsx
@@ -74,25 +74,27 @@ export function Summary({ data }) {
 							</li>
 						))}
 					</ol>
+
+					{mostNeglectedItems.length ? ( //if not length, it still shows heading below because the variable exists as empty array
+						<>
+							<h3>Did you forget about these?</h3>
+
+							{mostNeglectedItems.map((item) => (
+								<div key={item.itemId}>
+									The item "{item.name}" is{' '}
+									{getDaysBetweenDates(item.refTime, currentTime)} days old and
+									was never purchased.
+								</div> //ambivalent about this one and also where the logic is
+							))}
+						</>
+					) : (
+						<h3>
+							You've bought everything on your list at least once! Good job.
+						</h3>
+					)}
 				</div>
 			) : (
 				<p>No purchase history found.</p>
-			)}
-
-			{mostNeglectedItems.length ? ( //if not length, it still shows heading below because the variable exists as empty array
-				<>
-					<h3>Did you forget about these?</h3>
-
-					{mostNeglectedItems.map((item) => (
-						<div key={item.itemId}>
-							The item "{item.name}" is{' '}
-							{getDaysBetweenDates(item.refTime, currentTime)} days old and was
-							never purchased.
-						</div> //ambivalent about this one and also where the logic is
-					))}
-				</>
-			) : (
-				<h3>You've bought everything on your list at least once! Good job.</h3>
 			)}
 
 			<h2>Personal Goals</h2>

--- a/src/views/Summary.jsx
+++ b/src/views/Summary.jsx
@@ -1,0 +1,97 @@
+import { useState, useMemo } from 'react';
+import { getDaysBetweenDates } from '../utils';
+import { comparePurchaseUrgency } from '../utils/item';
+
+export function Summary({ data }) {
+	const [goals, setGoals] = useState(''); //these should be drawn from association with userID, if we build out user database
+
+	// duplicated fr List - not set up when data is passed to this component
+	const sortedFullList = useMemo(() => comparePurchaseUrgency(data), [data]);
+
+	/**
+    Summary of data keys - to remove on finalization
+  
+	itemId,
+	name,
+	isChecked,
+	dateCreated,
+	dateLastPurchased,
+	dateNextPurchased,
+	totalPurchases,
+	refTime,
+	daysToNext,
+    */
+
+	//memoize below?
+	const getPurchased = (array) =>
+		array.filter((item) => item.dateLastPurchased); //purchased at least once, not null value
+	const getOldest = (array) => {
+		const refTimesOnly = array.map((item) => item.refTime);
+		return array.filter((item) => item.refTime === Math.min(...refTimesOnly)); //there may be more than one, so not using find()
+	};
+	const getFiveMost = (array, metric) => {
+		const arr = [...array].sort((a, b) => b[metric] - a[metric]); //when passing in date in MS, larger is also more recent
+		arr.length = 5;
+		return arr;
+	};
+
+	const currentTime = new Date().getTime();
+	const purchased = getPurchased(sortedFullList);
+	const fiveMostRecentPurchases = getFiveMost(purchased, 'refTime'); //descending order of most recently purchased items
+	const fiveMostPurchased = getFiveMost(purchased, 'totalPurchases');
+	const mostPurchased = [...purchased].filter(
+		(item) => item.totalPurchases === Math.max(),
+	);
+	const mostNeglectedItems = getOldest(
+		sortedFullList.filter((item) => !item.dateLastPurchased),
+	); //oldest never purchased item(s)
+
+	return (
+		<div className="Summary">
+			{purchased.length ? (
+				<div>
+					<h2>Your purchase history to date</h2>
+					<h3>Five most frequently purchased items:</h3>
+					<ul>
+						{fiveMostPurchased.map((item) => (
+							<li key={item.itemId}>
+								{item.name}: bought {item.totalPurchases} times
+							</li>
+						))}
+					</ul>
+
+					<h3>Five most recent purchases:</h3>
+					<ul>
+						{fiveMostRecentPurchases.map((item) => (
+							<li key={item.itemId}>
+								{item.name}: bought on{' '}
+								{item.dateLastPurchased
+									.toDate()
+									.toLocaleDateString('en-us', {
+										weekday: 'long',
+										year: 'numeric',
+										month: 'short',
+										day: 'numeric',
+									})}
+							</li>
+						))}
+					</ul>
+
+					<h3>Item(s) you may have forgotten about:</h3>
+					<ul>
+						{mostNeglectedItems.map((item) => (
+							<li key={item.itemId}>
+								{item.name} is {getDaysBetweenDates(item.refTime, currentTime)}{' '}
+								days old and was never purchased.
+							</li> //ambivalent about this one and also where the logic is
+						))}
+					</ul>
+				</div>
+			) : (
+				<p>No purchase history found.</p>
+			)}
+			<h2>Personal Goals</h2>
+			{goals ? <p>{goals}</p> : 'Set some goals for your shopping habits!'}
+		</div>
+	);
+}

--- a/src/views/Summary.jsx
+++ b/src/views/Summary.jsx
@@ -63,7 +63,12 @@ export function Summary({ data }) {
 					<ol>
 						{fiveMostPurchased.map((item) => (
 							<li key={item.itemId}>
-								{item.name}: bought {item.totalPurchases} times
+								{item.name}: bought{' '}
+								{item.totalPurchases === 1 ? (
+									<span>{item.totalPurchases} time</span>
+								) : (
+									<span>{item.totalPurchases} times</span>
+								)}
 							</li>
 						))}
 					</ol>
@@ -89,9 +94,11 @@ export function Summary({ data }) {
 
 							{mostNeglectedItem.map((item) => (
 								<div key={item.itemId}>
-									The item "{item.name}" is{' '}
-									{getDaysBetweenDates(item.refTime, currentTime)} days old and
-									was never purchased.
+									<p>
+										The item "{item.name}" is{' '}
+										{getDaysBetweenDates(item.refTime, currentTime)} days old
+										and was never purchased.
+									</p>
 								</div> //ambivalent about this one and also where the logic is
 							))}
 						</>

--- a/src/views/Summary.jsx
+++ b/src/views/Summary.jsx
@@ -5,12 +5,6 @@ import { comparePurchaseUrgency } from '../utils/item';
 export function Summary({ data }) {
 	const [goals, setGoals] = useState(''); //these should be drawn from association with userID, if we build out user database
 
-	// duplicated fr List - not set up when data is passed to this component. get rid of placeholder as well
-	const sortedFullList = useMemo(
-		() => comparePurchaseUrgency(data.filter((item) => item.name !== '')),
-		[data],
-	);
-
 	/**
     Summary of data keys - to remove on finalization
   
@@ -38,6 +32,17 @@ export function Summary({ data }) {
 		return arr;
 	};
 
+	const removePlaceholder = (array) => {
+		return array.filter((item) => item.name !== '');
+	};
+
+	// duplicated fr List - not set up when data is passed to this component.
+	// but unlike List's similar variable, the placeholder is removed at this time
+	const sortedFullList = useMemo(
+		() => removePlaceholder(comparePurchaseUrgency(data)),
+		[data],
+	);
+
 	const currentTime = new Date().getTime();
 	const purchased = getPurchased(sortedFullList);
 	const fiveMostRecentPurchases = getFiveMost(purchased, 'refTime'); //descending order of most recently purchased items
@@ -45,9 +50,9 @@ export function Summary({ data }) {
 	const mostPurchased = [...purchased].filter(
 		(item) => item.totalPurchases === Math.max(),
 	);
-	const mostNeglectedItems = getOldest(
+	const mostNeglectedItem = getOldest(
 		sortedFullList.filter((item) => !item.dateLastPurchased),
-	); //oldest never purchased item(s)
+	); //oldest never purchased item
 
 	return (
 		<div className="Summary">
@@ -78,11 +83,11 @@ export function Summary({ data }) {
 						))}
 					</ol>
 
-					{mostNeglectedItems.length ? ( //need to hide placeholder item
+					{mostNeglectedItem.length ? ( //need to hide placeholder item
 						<>
 							<h3>Did you forget about these?</h3>
 
-							{mostNeglectedItems.map((item) => (
+							{mostNeglectedItem.map((item) => (
 								<div key={item.itemId}>
 									The item "{item.name}" is{' '}
 									{getDaysBetweenDates(item.refTime, currentTime)} days old and

--- a/src/views/Summary.jsx
+++ b/src/views/Summary.jsx
@@ -16,9 +16,6 @@ export function Summary({ data, goal }) {
 
 	const editGoals = (e) => {
 		e.preventDefault();
-		if (!isDisabled) {
-			updateGoals(e);
-		}
 		setIsDisabled(!isDisabled);
 	};
 

--- a/src/views/Summary.jsx
+++ b/src/views/Summary.jsx
@@ -1,16 +1,13 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { getDaysBetweenDates, useStateWithStorage } from '../utils';
 import { comparePurchaseUrgency } from '../utils/item';
 import { Goals } from '../components/Goals';
 
-export function Summary({ data }) {
+export function Summary({ data, goal }) {
 	// as noted in Goals - componetize here and fr multList approach
 	const [isDisabled, setIsDisabled] = useState(true);
 
-	const [goals, setGoals] = useStateWithStorage(
-		'Set a goal for your shopping habits!',
-		'tcl-shopping-list-goals',
-	); //these should be drawn from association with userID, if we build out user database
+	const [goals, setGoals] = goal;
 
 	const updateGoals = (e) => {
 		const newGoal = e.target.value;
@@ -24,6 +21,10 @@ export function Summary({ data }) {
 		}
 		setIsDisabled(!isDisabled);
 	};
+
+	useEffect(() => {
+		console.log(data.map((item) => Object.entries(item)));
+	});
 
 	//memoize below?
 	const getPurchased = (array) =>
@@ -68,7 +69,7 @@ export function Summary({ data }) {
 					<h3>Top 5 purchases by frequency:</h3>
 					<ol>
 						{fiveMostPurchased.map((item) => (
-							<li key={item.itemId}>
+							<li key={item.id}>
 								{item.name}: bought{' '}
 								{item.totalPurchases === 1 ? (
 									<span>{item.totalPurchases} time</span>
@@ -82,7 +83,7 @@ export function Summary({ data }) {
 					<h3>5 most recent purchases:</h3>
 					<ol>
 						{fiveMostRecentPurchases.map((item) => (
-							<li key={item.itemId}>
+							<li key={item.id}>
 								{item.name}: bought on{' '}
 								{item.dateLastPurchased.toDate().toLocaleDateString('en-us', {
 									weekday: 'long',
@@ -99,7 +100,7 @@ export function Summary({ data }) {
 							<h3>Did you forget about these?</h3>
 
 							{mostNeglectedItem.map((item) => (
-								<div key={item.itemId}>
+								<div key={item.id}>
 									<p>
 										The item "{item.name}" is{' '}
 										{getDaysBetweenDates(item.refTime, currentTime)} days old

--- a/src/views/Summary.jsx
+++ b/src/views/Summary.jsx
@@ -5,8 +5,11 @@ import { comparePurchaseUrgency } from '../utils/item';
 export function Summary({ data }) {
 	const [goals, setGoals] = useState(''); //these should be drawn from association with userID, if we build out user database
 
-	// duplicated fr List - not set up when data is passed to this component
-	const sortedFullList = useMemo(() => comparePurchaseUrgency(data), [data]);
+	// duplicated fr List - not set up when data is passed to this component. get rid of placeholder as well
+	const sortedFullList = useMemo(
+		() => comparePurchaseUrgency(data.filter((item) => item.name !== '')),
+		[data],
+	);
 
 	/**
     Summary of data keys - to remove on finalization
@@ -75,7 +78,7 @@ export function Summary({ data }) {
 						))}
 					</ol>
 
-					{mostNeglectedItems.length ? ( //if not length, it still shows heading below because the variable exists as empty array
+					{mostNeglectedItems.length ? ( //need to hide placeholder item
 						<>
 							<h3>Did you forget about these?</h3>
 
@@ -89,7 +92,7 @@ export function Summary({ data }) {
 						</>
 					) : (
 						<h3>
-							You've bought everything on your list at least once! Good job.
+							You have bought everything on your list at least once. Good job!
 						</h3>
 					)}
 				</div>

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -2,3 +2,4 @@ export * from './AddItem';
 export * from './Home';
 export * from './Layout';
 export * from './List';
+export * from './Summary';


### PR DESCRIPTION
## Description
Adds a page that summarizes some purchase stats for the user to consider. 
The purchase stats are currently built from only the list associated with the active list token. 
Added locally stored user goals component: Leverages approach from [PR for multiple lists](https://github.com/the-collab-lab/tcl-46-smart-shopping-list/pull/35) and adds a check to ensure goal string is not empty. Potential for refactoring to extract reused code.

Not yet styled - definitely would want this to also have some personality or interactivity.

**Considerations**
- Potential area to encourage user to add new goals (not yet built out as part of the issue). If we are going the user database route, this goal could be retrieved from the associated user doc. Ideally we decide if we move forward with that, or else this would be limited to local setup. 
- Because it's in local storage, **when a user starts a new list on the same device, their previous goals remain and do not follow the specific list.** 
  - Should goals follow the list? (especially considering when the list is shared with another user, not just to another device)
- Also of interest is: user purchase history across collections (lists) associated with their id? Given the collections are not structurally associated with the user in the above scenario, this would require more complicated querying.

## Related Issue

Closes #41 
## Acceptance Criteria

- [x] Top [number here] most purchased items to-date (it may be difficult to time-box in a custom date range but we can also think of how to set up to enable that)
-  [x] Most recently purchased item(s)
-  [x] Neglected item feature (never bought, oldest item based on dateCreated)
- [x] Personal goals component. **Currently stored locally.**

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

(No summary page)
![before_issue41](https://user-images.githubusercontent.com/102257735/185513161-bfa25355-203d-48b2-af65-594ac4506d60.png)


### After

Has purchase history
![after_issue41](https://user-images.githubusercontent.com/102257735/185687885-06c4fe38-9294-4888-8502-be4a1d787ee3.png)

No purchase history
![after_issue41-nopurchase](https://user-images.githubusercontent.com/102257735/185687913-ffa7bbeb-2435-4aa9-9f92-b95b4703a552.png)


## Testing Steps / QA Criteria
Pull and check out branch `hy-feat-statsGoals`.

View Summary page with an existing list with several purchased items and not purchased items, as well as after generating a new list from the Home page. 

Edit the goal placeholder and change lists. The goal will persist across lists (remain in local storage).