### PR TITLE
Firebase PR Preview on Dev branch

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -5,7 +5,6 @@ name: Deploy to Firebase Hosting on PR
 'on': pull_request
 jobs:
   build_and_preview:
-    if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Description

Removed "if head branch" line from Firebase yml to allow hosting preview on PR to run on our dev branch as well as main.

## Related Issue

Closes #46 


## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

We now have this preview bot again y ay

![image](https://user-images.githubusercontent.com/77255525/185755501-62ec5312-1808-453d-b62e-613547c210e9.png)


