### PR TITLE
Remove export options if no valid listToken

### DIFF
--- a/src/components/AddItem.tsx
+++ b/src/components/AddItem.tsx
@@ -2,7 +2,7 @@ import { useState, useContext } from 'react';
 import { MyContext } from '../App';
 import { isEmpty, isDuplicate } from '../utils/validateStrings';
 import { addItem } from '../api/firebase';
-import NoToken from '../components/NoToken';
+import NoToken from './NoToken';
 import { getUserListsArr } from '../utils/user';
 
 const defaultItem = { itemName: '', daysUntilNextPurchase: 7 };

--- a/src/components/CopyToken.tsx
+++ b/src/components/CopyToken.tsx
@@ -26,7 +26,7 @@ export function CopyToken({ listToken, userList }) {
 			<label htmlFor="userList">
 				Select list to share:
 				<select
-					value={selectedListToken}
+					value={selectedListToken | ''}
 					onChange={updateSelectedList}
 					id="userList"
 				>

--- a/src/components/CopyToken.tsx
+++ b/src/components/CopyToken.tsx
@@ -26,7 +26,7 @@ export function CopyToken({ listToken, userList }) {
 			<label htmlFor="userList">
 				Select list to share:
 				<select
-					value={selectedListToken | ''}
+					value={selectedListToken || ''}
 					onChange={updateSelectedList}
 					id="userList"
 				>

--- a/src/components/ListSwitcher.tsx
+++ b/src/components/ListSwitcher.tsx
@@ -3,7 +3,7 @@ import { MyContext } from '../App';
 import { getUserListsArr } from '../utils/user';
 
 const ListSwitcher = ({ switchList, rmListUpdate }) => {
-	const [userList, setUserList] = useContext(MyContext).userListCtx;
+	const [userList] = useContext(MyContext).userListCtx;
 	return (
 		<div>
 			<h1>My Lists</h1>

--- a/src/views/Export.tsx
+++ b/src/views/Export.tsx
@@ -2,6 +2,8 @@ import { Calendar } from '../components/Calendar';
 import { useContext } from 'react';
 import { MyContext } from '../App';
 import { CopyToken } from '../components/CopyToken';
+import { getUserListsArr } from '../utils/user';
+import NoToken from '../components/NoToken';
 export function Export() {
 	const [adjustedData] = useContext(MyContext).adjustedDataCtx;
 	const [listToken, setListToken] = useContext(MyContext).listTokenCtx;
@@ -9,12 +11,20 @@ export function Export() {
 
 	return (
 		<>
-			<Calendar listOfShoppingListItems={adjustedData} />
-			<CopyToken
-				listToken={listToken}
-				setListToken={setListToken}
-				userList={userList}
-			/>
+			{listToken !== 'null' && getUserListsArr(userList) ? (
+				<>
+					<Calendar listOfShoppingListItems={adjustedData} />
+					<CopyToken
+						listToken={listToken}
+						setListToken={setListToken}
+						userList={userList}
+					/>
+				</>
+			) : (
+				<NoToken />
+			)}
 		</>
 	);
 }
+
+// bug of empty new name string reappeared

--- a/src/views/Export.tsx
+++ b/src/views/Export.tsx
@@ -1,17 +1,21 @@
 import { Calendar } from '../components/Calendar';
-import { useContext } from 'react';
+import { useContext, useEffect } from 'react';
 import { MyContext } from '../App';
 import { CopyToken } from '../components/CopyToken';
-import { getUserListsArr } from '../utils/user';
 import NoToken from '../components/NoToken';
 export function Export() {
 	const [adjustedData] = useContext(MyContext).adjustedDataCtx;
 	const [listToken, setListToken] = useContext(MyContext).listTokenCtx;
 	const [userList] = useContext(MyContext).userListCtx;
 
+	const isValidToken = (token) => {
+		const regexPattern = /(?:\w+ ){2}\w+/;
+		return regexPattern.test(token);
+	};
+
 	return (
 		<>
-			{listToken && listToken !== 'null' ? (
+			{listToken && isValidToken(listToken) ? (
 				<>
 					<Calendar listOfShoppingListItems={adjustedData} />
 					<CopyToken
@@ -26,5 +30,3 @@ export function Export() {
 		</>
 	);
 }
-
-// bug of empty new name string reappeared

--- a/src/views/Export.tsx
+++ b/src/views/Export.tsx
@@ -11,7 +11,7 @@ export function Export() {
 
 	return (
 		<>
-			{listToken !== 'null' && getUserListsArr(userList) ? (
+			{listToken && listToken !== 'null' ? (
 				<>
 					<Calendar listOfShoppingListItems={adjustedData} />
 					<CopyToken

--- a/src/views/List.tsx
+++ b/src/views/List.tsx
@@ -12,6 +12,7 @@ import {
 	updateName,
 	isDuplicateName,
 } from '../utils/user';
+import { isEmpty } from '../utils';
 import NoToken from '../components/NoToken';
 
 import ListTitle from '../components/ListTitle';
@@ -131,7 +132,7 @@ export function List() {
 
 		if (isDisabled) return;
 
-		if (listName === '' || isDuplicateName(userList, listName, listToken)) {
+		if (isEmpty(listName) || isDuplicateName(userList, listName, listToken)) {
 			setListName(listToken);
 			setUserList(updateName(userList, listToken));
 		} else setUserList(updateName(userList, listToken, listName));

--- a/src/views/List.tsx
+++ b/src/views/List.tsx
@@ -14,10 +14,9 @@ import {
 } from '../utils/user';
 import NoToken from '../components/NoToken';
 
-import ListSwitcher from '../components/ListSwitcher';
 import ListTitle from '../components/ListTitle';
 import { MyContext } from '../App';
-import { AddItem } from './AddItem';
+import { AddItem } from '../components/AddItem';
 
 const defaultDates = { startDate: '', endDate: '' };
 
@@ -87,20 +86,6 @@ export function List() {
 		return list.filter(({ name }) =>
 			cleanup(name).includes(cleanup(searchTerm)),
 		);
-	};
-
-	const switchList = (token) => {
-		setListToken(token);
-	};
-
-	const rmListUpdate = (name, token) => {
-		const updatedList = removeList(userList, name);
-
-		setUserList(updatedList);
-
-		if (token === listToken) {
-			setListToken(getFirstToken(JSON.parse(updatedList)));
-		}
 	};
 
 	const clearSearchTerm = () => {
@@ -254,11 +239,6 @@ export function List() {
 							))}
 						</ul>
 						<button onClick={deleteList}>Delete List</button>
-						<ListSwitcher
-							userList={userList}
-							switchList={switchList}
-							rmListUpdate={rmListUpdate}
-						/>
 					</div>
 				) : (
 					<div>


### PR DESCRIPTION
## Description
When user has no active list, all Export options are hidden and replaced with prompt to create a list.
The conditional checks if the user has a listToken and whether the value is a valid listToken using regex pattern. 

## Related Issue
Closes #65 

## Acceptance Criteria
- [x] Hide copy token option or potentially all Export options if listToken is null.

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
|    | :sparkles: New feature     |
|  ✓   | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before
![issue_null_Token](https://user-images.githubusercontent.com/102257735/186344742-707f16b1-c7b8-4970-8b74-0283e7bcbe84.png)

### After
When no listToken or listToken value is invalid:
![issue_notoken_export](https://user-images.githubusercontent.com/102257735/186460202-d691663f-fb47-4d49-bba9-c009208b262a.png)

## Testing Steps / QA Criteria
Clear any local storage values for "tcl-shopping-list-token", manually replace its value with an invalid value (not string of three alphanumeric substrings), or remove the key "tcl-shopping-list-token" entirely. Export should show as the above "after" screen.