### PR TITLE
Add custom checkbox and fix calendar text

### DIFF
--- a/public/img/checkmark-dark.svg
+++ b/public/img/checkmark-dark.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="11" viewBox="0 0 12 11" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 5.39883L4.76944 10C6.20688 6.60157 8.32801 3.53761 11 1" stroke="#CFB297" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/img/checkmark-light.svg
+++ b/public/img/checkmark-light.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="11" viewBox="0 0 12 11" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 5.39883L4.76944 10C6.20688 6.60157 8.32801 3.53761 11 1" stroke="#E77812" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/ListItem.css
+++ b/src/components/ListItem.css
@@ -1,5 +1,5 @@
 .ListItem {
-	background-color: var(--color-listitem-bg);
+	background-color: var(--color-list-item);
 
 	width: 100%;
 
@@ -48,13 +48,11 @@
 }
 
 .ListItem-checkbox {
-	accent-color: var(--color-accent);
-
-	margin: 0;
-	padding: 0;
-
-	height: 44px;
-	aspect-ratio: 1/1;
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	overflow: hidden;
+	clip: rect(0 0 0 0);
 }
 
 .section-label {
@@ -65,6 +63,33 @@
 	padding: 0 1.6rem 3.4rem 1.6rem;
 
 	border-bottom: solid 2px var(--color-text);
+}
+
+.visible-checkbox {
+	height: 44px;
+	width: 44px;
+	display: inline-flex;
+	border: 1.5px solid navy;
+	vertical-align: middle;
+	border-radius: 25%;
+	accent-color: var(--color-accent);
+	background-color: var(--color-bg);
+	border: none;
+}
+
+.visible-checkbox::after {
+	background-image: var(--svg-checkmark);
+	background-repeat: no-repeat;
+	background-position: center;
+	opacity: 0;
+	display: inline-block;
+	width: 100%;
+	height: 100%;
+	content: '';
+}
+
+.ListItem-checkbox:checked + .visible-checkbox::after {
+	opacity: 1;
 }
 
 .delete-button {

--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -99,15 +99,18 @@ export function ListItem({
 			</div>
 
 			<div className="section-checkbox">
-				<input
-					className="ListItem-checkbox"
-					type="checkbox"
-					id={name}
-					name={name}
-					value={name}
-					onChange={handleValueChange}
-					defaultChecked={isChecked}
-				/>
+				<label className="checkbox__label" htmlFor={name}>
+					<input
+						className="ListItem-checkbox"
+						type="checkbox"
+						id={name}
+						name={name}
+						value={name}
+						onChange={handleValueChange}
+						defaultChecked={isChecked}
+					/>
+					<span className="visible-checkbox"></span>
+				</label>
 			</div>
 
 			<button className="delete-button" type="button" onClick={handleDelete}>

--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,10 @@
 	--color-dusty-gray: #7b7366;
 	--color-brown: #94744e;
 	--color-dark-peach: #cfb297;
+	--color-tan: #cac1ac;
+	--color-burgundy: #835151;
+	--svg-dark-checkmark: url(../public/img/checkmark-dark.svg);
+	--svg-light-checkmark: url(../public/img/checkmark-light.svg);
 }
 
 @media (prefers-color-scheme: light) {
@@ -22,6 +26,9 @@
 		--color-dark-accent: var(--color-black-accent);
 		--color-button: var(--color-cream);
 		--color-select: var(--color-cream);
+		--color-list-item: var(--color-cream);
+		--color-calendar-text: var(--color-burgundy);
+		--svg-checkmark: var(--svg-light-checkmark);
 	}
 }
 
@@ -36,6 +43,9 @@
 		--color-dark-accent: var(--color-black-accent);
 		--color-button: var(--color-dusty-gray);
 		--color-select: var(--color-black-accent);
+		--color-list-item: var(--color-black-accent);
+		--color-calendar-text: var(--color-tan);
+		--svg-checkmark: var(--svg-dark-checkmark);
 	}
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -11,6 +11,7 @@
 	--color-dark-peach: #cfb297;
 	--color-tan: #cac1ac;
 	--color-burgundy: #835151;
+	--color-off-cream: #f3eee7;
 	--svg-dark-checkmark: url(../public/img/checkmark-dark.svg);
 	--svg-light-checkmark: url(../public/img/checkmark-light.svg);
 }
@@ -28,6 +29,7 @@
 		--color-select: var(--color-cream);
 		--color-list-item: var(--color-cream);
 		--color-calendar-text: var(--color-burgundy);
+		--color-calendar-button: var(--color-off-cream);
 		--svg-checkmark: var(--svg-light-checkmark);
 	}
 }
@@ -45,6 +47,7 @@
 		--color-select: var(--color-black-accent);
 		--color-list-item: var(--color-black-accent);
 		--color-calendar-text: var(--color-tan);
+		--color-calendar-button: var(--color-black-accent);
 		--svg-checkmark: var(--svg-dark-checkmark);
 	}
 }

--- a/src/views/Export.css
+++ b/src/views/Export.css
@@ -89,6 +89,7 @@
 	padding: 20px 30px;
 	font-size: 20px;
 	color: var(--color-calendar-text);
+	background-color: var(--color-calendar-button);
 }
 
 @media screen and (max-width: 768px) {

--- a/src/views/Export.css
+++ b/src/views/Export.css
@@ -18,6 +18,7 @@
 	grid-template-areas: 'message dropdown button';
 	gap: 10px;
 	width: 100%;
+	justify-content: center;
 }
 .export__footer {
 	margin-top: 30px;
@@ -49,7 +50,7 @@
 	padding: 10px 20px;
 	border: none;
 	grid-area: button;
-	min-width: 90px;
+	width: 90px;
 }
 .calendar {
 	display: flex;
@@ -107,5 +108,14 @@
 	}
 	.copytoken__select {
 		width: 191px;
+	}
+}
+
+@media screen and (max-width: 375px) {
+	.copytoken {
+		grid-template-areas:
+			'message message'
+			'dropdown dropdown'
+			'button button';
 	}
 }

--- a/src/views/Export.css
+++ b/src/views/Export.css
@@ -88,6 +88,7 @@
 	border: none;
 	padding: 20px 30px;
 	font-size: 20px;
+	color: var(--color-calendar-text);
 }
 
 @media screen and (max-width: 768px) {


### PR DESCRIPTION

## Description

- small PR on custom checkbox to make the visual consistent across browsers. The color of the checkmark changes according to light/dark mode
- changed calendar text color and background color to be consistent with Figma light and dark mode
- adjusted copyToken's copy button width to not overflow

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### After
![Screen Shot 2022-08-25 at 10 48 06 PM](https://user-images.githubusercontent.com/90414254/186813417-3ffa0df6-a961-4544-b367-9ec2f6963e44.png)
![Screen Shot 2022-08-25 at 10 50 48 PM](https://user-images.githubusercontent.com/90414254/186813704-3c33949c-9a67-4e45-bce7-71021ee0c26a.png)

<!-- If UI feature, take provide screenshots -->

