### PR TITLE
No Token page styling + Avo update

### DIFF
--- a/src/components/FoodPuns.css
+++ b/src/components/FoodPuns.css
@@ -13,24 +13,25 @@
 .foodpuns {
 	cursor: pointer;
 	position: fixed;
-	bottom: 48px;
+	bottom: 40px;
 	z-index: 1;
 	right: 5%;
 }
 
 .hide {
+	border: var(--color-accent) solid 1px;
 	color: var(--color-orange);
 	border-radius: 24px;
 	font-size: 10px;
 	font-weight: 900;
-	padding: 10px 12px 10px 12px;
+	padding: 8px 12px 10px 12px;
 }
 
 @media only screen and (max-width: 600px) {
 	.foodpuns__content {
 		position: fixed;
 		bottom: 75px;
-		right: 25%;
-		width: 70vw;
+		left: 10%;
+		width: 50vw;
 	}
 }

--- a/src/components/FoodPuns.css
+++ b/src/components/FoodPuns.css
@@ -27,11 +27,20 @@
 	padding: 8px 12px 10px 12px;
 }
 
+.svg__icon {
+	width: 120px;
+	height: 160px;
+}
+
 @media only screen and (max-width: 600px) {
 	.foodpuns__content {
 		position: fixed;
 		bottom: 75px;
 		left: 10%;
 		width: 50vw;
+	}
+	.svg__icon {
+		width: 60px;
+		height: 100px;
 	}
 }

--- a/src/components/FoodPuns.tsx
+++ b/src/components/FoodPuns.tsx
@@ -30,8 +30,7 @@ function FoodPuns() {
 				<div>
 					<p className="foodpuns__content">{pun}</p>
 					<svg
-						width="70"
-						height="110"
+						className="svg__icon"
 						viewBox="0 0 39 54"
 						fill="none"
 						xmlns="http://www.w3.org/2000/svg"

--- a/src/components/FoodPuns.tsx
+++ b/src/components/FoodPuns.tsx
@@ -30,8 +30,8 @@ function FoodPuns() {
 				<div>
 					<p className="foodpuns__content">{pun}</p>
 					<svg
-						width="50"
-						height="60"
+						width="70"
+						height="110"
 						viewBox="0 0 39 54"
 						fill="none"
 						xmlns="http://www.w3.org/2000/svg"

--- a/src/components/NoToken.css
+++ b/src/components/NoToken.css
@@ -1,0 +1,38 @@
+.notoken__container {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-content: center;
+	text-align: center;
+	width: 50%;
+	height: 100%;
+	margin: auto;
+}
+
+h1 {
+	padding-top: 10%;
+}
+
+.notoken__container > h2,
+.notoken__footer {
+	padding-top: 25%;
+	padding-bottom: 25%;
+}
+
+.notoken__container button {
+	height: 50px;
+	width: 120px;
+	border-radius: 24px;
+}
+
+@media only screen and (min-width: 768px) {
+	.notoken__container {
+		width: 75%;
+	}
+}
+
+@media only screen and (min-width: 640px) {
+	.notoken__container {
+		width: 100%;
+	}
+}

--- a/src/components/NoToken.css
+++ b/src/components/NoToken.css
@@ -10,6 +10,7 @@
 }
 
 h1 {
+	font-weight: 400;
 	padding-top: 10%;
 }
 

--- a/src/components/NoToken.css
+++ b/src/components/NoToken.css
@@ -23,6 +23,7 @@ h1 {
 	height: 50px;
 	width: 120px;
 	border-radius: 24px;
+	font-size: 18px;
 }
 
 @media only screen and (min-width: 768px) {

--- a/src/components/NoToken.tsx
+++ b/src/components/NoToken.tsx
@@ -1,13 +1,19 @@
 import { Link } from 'react-router-dom';
+import './NoToken.css';
 
 const NoToken = () => {
 	return (
-		<div>
-			<h2>Oh Crêpe!</h2>
-			You do not have a list token! Please create one to start adding items.
+		<div className="notoken__container">
+			<h1>Oh Crêpe!</h1>
+			<h2>
+				You do not have a list token! Please create one to start adding items.
+			</h2>
 			<Link to="/">
 				<button type="button">Home</button>
 			</Link>
+			<p className="notoken__footer">
+				This shopping app was created with love by members of The Collab Lab.
+			</p>
 		</div>
 	);
 };

--- a/src/views/Export.tsx
+++ b/src/views/Export.tsx
@@ -26,10 +26,6 @@ export function Export() {
 			) : (
 				<NoToken />
 			)}
-
-			<p className="export__footer">
-				This shopping app was created with love by members of The Collab Lab.
-			</p>
 		</>
 	);
 }


### PR DESCRIPTION
## Description

Styled that no token page + added outline around hide button for avocado + made him bigger for desktop, smaller for mobile

## Related Issue

Closes #97 

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates


### After

![image](https://user-images.githubusercontent.com/77255525/187041196-b8dc6e02-dae5-4b0a-865c-d2e64aef0dcf.png)
![image](https://user-images.githubusercontent.com/77255525/187041201-81ad60ba-cb03-4464-8e54-5318cf8b8acb.png)

