### PR TITLE
Fix details

### DIFF
--- a/src/components/AddItem.css
+++ b/src/components/AddItem.css
@@ -140,10 +140,12 @@
 	}
 	.p__hasItems {
 		text-align: center;
+		margin-bottom: 5px;
 	}
 	.addItem__label__hasItems {
 		display: flex;
 		flex-direction: column;
+		margin-top: 10px;
 	}
 
 	.addItem__label {

--- a/src/components/Filter.tsx
+++ b/src/components/Filter.tsx
@@ -14,18 +14,16 @@ const Filter = ({ searchTerm, setSearchTerm, setAdjustedData }) => {
 
 	const sortedFullList = useMemo(() => comparePurchaseUrgency(data), [data]);
 
-	const mediaChecker = window.matchMedia('only screen and (max-width: 588px)');
-
-	const [isMobile, setIsMobile] = useState(false);
-	const checkIfMobile = () => {
-		if (mediaChecker.matches) setIsMobile(true);
-		else setIsMobile(false);
-	};
+	const [isMobile, setIsMobile] = useState(window.innerWidth < 588);
 
 	useEffect(() => {
-		mediaChecker.addEventListener('change', checkIfMobile);
-		return () => mediaChecker.removeEventListener('change', checkIfMobile);
-	}, [mediaChecker]);
+		window.addEventListener('resize', () => {
+			setIsMobile(document.body.clientWidth < 588);
+		});
+		return window.removeEventListener('resize', () => {
+			setIsMobile(document.body.clientWidth < 588);
+		});
+	}, []);
 
 	useEffect(() => {
 		setAdjustedData(
@@ -35,10 +33,6 @@ const Filter = ({ searchTerm, setSearchTerm, setAdjustedData }) => {
 				.filter(customDateRange(custom.startDate, custom.endDate)),
 		);
 	}, [urgencyTerm, sortedFullList, custom, searchTerm]);
-
-	// const undoUrgency = () => setUrgencyTerm('ALL');
-	// const clearSearchTerm = () => setSearchTerm('');
-	// const clearDateRange = () => setCustom(defaultDates)
 
 	const clearAllFilters = () => {
 		setUrgencyTerm('ALL');

--- a/src/components/FoodPuns.css
+++ b/src/components/FoodPuns.css
@@ -26,6 +26,7 @@
 	font-size: 10px;
 	font-weight: 900;
 	padding: 8px 12px 10px 12px;
+	filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
 }
 
 .svg__icon {

--- a/src/views/Home.css
+++ b/src/views/Home.css
@@ -37,7 +37,7 @@
 
 .input__primary {
 	padding: 0.5em;
-	margin: 0.5rem;
+	margin: 0.5em;
 	font-size: 1.6rem;
 	text-align: center;
 	width: calc(100% - 140px);
@@ -45,19 +45,18 @@
 
 .input__primary.no-token {
 	font-size: 2rem;
-	margin: 1em;
-	width: 300px;
+	width: 100%;
 	text-align: center;
 }
 
 .btn__primary {
-	padding: 0.5em 2em;
-	width: 140px;
+	padding: 0.5em 1.5em;
+	width: fit-content;
 	border-radius: 2rem;
 }
 
 .btn__primary.no-token {
-	margin-top: 2em;
+	font-size: 1em;
 }
 
 .container__token-detail {
@@ -187,6 +186,7 @@
 	}
 	.input__primary {
 		width: 100%;
+		margin: 0.5em;
 	}
 	.btn__primary {
 		margin-top: 15px;


### PR DESCRIPTION

## Description

- fix <details> element not being collapsable upon page refresh by setting `isMobile` initial state to be a boolean `window.innerWidth < 588`, this way the `isMobile` is measured upon page refresh
- the previous way did not work because the `window.innerWidth` was in a `useEffect`, so if the width of the window does not change (which it doesn't upon refresh), then the code won't run, and the state won't change, and the html will not be conditionally rendered
- added a drop shadow to the hide icon in Avocado too


## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓   | :bug: Bug fix              |
|    | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

